### PR TITLE
[OCP] - Add creation of gcp credentials

### DIFF
--- a/docs/config-sample.yml
+++ b/docs/config-sample.yml
@@ -31,11 +31,29 @@ clusters:
       instance_type: m5.xlarge
     creds_type: aws
     openshift_version: "4.12"  # Optional. If not specified, will deploy the latest stable version
+  - name: cluster2
+    base_domain: <cluster_base_domain>
+    network:
+      cluster: 10.128.0.0/14
+      machine: 10.0.0.0/16
+      service: 172.30.0.0/16
+      type: OVNKubernetes
+    cloud:
+      platform: gcp
+      region: us-east1
+      instance_type: n1-standard-4
+      project_id: gcp_project_name
+    creds_type: gcp
 
 clusters_credentials:
   aws:
     aws_access_key_id: <aws_access_key_id>
     aws_secret_access_key: <aws_secret_access_key>
+  gcp:
+    os_service_account_json: |
+      {
+        ...content of osServiceAccount.json...
+      }
 
 ###########
 # ACM role

--- a/docs/ocp.md
+++ b/docs/ocp.md
@@ -31,7 +31,7 @@ ssh_pub_key:
 Provide the details of the clusters that needs to be deployed.
 ```
 clusters:
-  - name: test-cluster
+  - name: test-cluster1
     base_domain: example.com
     network:
       cluster: 10.128.0.0/14
@@ -45,6 +45,20 @@ clusters:
     creds_type: aws
     openshift_version: "4.12"  # Optional variable to set OCP version per cluster
     fips: true  # Optional variable to enable FIPS on cluster
+
+  - name: test-cluster2
+    base_domain: example.com
+    network:
+      cluster: 10.128.0.0/14
+      machine: 10.0.0.0/16
+      service: 172.30.0.0/16
+      type: OVNKubernetes
+    cloud:
+      platform: gcp
+      region: us-east1
+      instance_type: n1-standard-4
+      project_id: gcp_project_name
+    creds_type: gcp
 ```
 
 #### Clusters credentials
@@ -54,6 +68,12 @@ clusters_credentials:
   aws:
     aws_access_key_id: <your_key_id>
     aws_secret_access_key: <your_access_key>
+
+  gcp:
+    os_service_account_json: |
+      {
+        ...content of osServiceAccount.json...
+      }
 ```
 
 #### Openshift version

--- a/roles/ocp/tasks/creds.yml
+++ b/roles/ocp/tasks/creds.yml
@@ -1,7 +1,15 @@
 ---
+- name: Set filename to store the creds in
+  ansible.builtin.set_fact:
+    creds_file: "{%- if item.creds_type == 'aws' -%}
+                 credentials
+                 {%- elif item.creds_type == 'gcp' -%}
+                 osServiceAccount.json
+                 {%- endif -%}"
+
 - name: Verify openshift cloud credentials
   ansible.builtin.stat:
-    path: "{{ lookup('env', 'HOME') }}/.{{ item.creds_type }}/credentials"
+    path: "{{ lookup('env', 'HOME') }}/.{{ item.creds_type }}/{{ creds_file }}"
   register: cloud_creds
 
 - block:
@@ -14,6 +22,6 @@
     - name: Create cloud credentials file
       ansible.builtin.template:
         src: cloud-creds.j2
-        dest: "{{ lookup('env', 'HOME') }}/.{{ item.creds_type }}/credentials"
+        dest: "{{ lookup('env', 'HOME') }}/.{{ item.creds_type }}/{{ creds_file }}"
         mode: 0600
   when: not cloud_creds.stat.exists

--- a/roles/ocp/templates/cloud-creds.j2
+++ b/roles/ocp/templates/cloud-creds.j2
@@ -2,4 +2,6 @@
 [default]
 aws_access_key_id = {{ clusters_credentials[item.creds_type].aws_access_key_id }}
 aws_secret_access_key = {{ clusters_credentials[item.creds_type].aws_secret_access_key }}
+{% elif item.creds_type == "gcp" %}
+{{ clusters_credentials[item.creds_type].os_service_account_json }}
 {% endif %}

--- a/roles/ocp/templates/install-config.yaml.j2
+++ b/roles/ocp/templates/install-config.yaml.j2
@@ -7,6 +7,10 @@ compute:
   platform:
     aws:
       type: {{ item.cloud.instance_type }}
+{% elif item.cloud.platform == "gcp" and item.cloud.instance_type is defined %}
+  platform:
+    gcp:
+      type: {{ item.cloud.instance_type }}
 {% else %}
   platform: {}
 {% endif %}
@@ -17,6 +21,10 @@ controlPlane:
 {% if item.cloud.platform == "aws" and item.cloud.instance_type is defined %}
   platform:
     aws:
+      type: {{ item.cloud.instance_type }}
+{% elif item.cloud.platform == "gcp" and item.cloud.instance_type is defined %}
+  platform:
+    gcp:
       type: {{ item.cloud.instance_type }}
 {% else %}
   platform: {}


### PR DESCRIPTION
Add GCP credentials creation on the controller machine during openshift cluster creation.
In case such credentials are missing, need to create them to prevent cloud platform login failure.