### PR TITLE
[ACM] - Fix acm roles CSV check failure

### DIFF
--- a/roles/acm/tasks/deploy.yml
+++ b/roles/acm/tasks/deploy.yml
@@ -103,6 +103,8 @@
   register: acm_csv
   until:
     - acm_csv.resources | length > 0
+    - "'status' in acm_csv.resources[0]"
+    - "'phase' in acm_csv.resources[0].status"
     - acm_csv.resources[0].status.phase == "Succeeded"
   retries: 15
   delay: 10


### PR DESCRIPTION
When performing ACM Hib deploy, as part of the deploy flow, CSV that has been created after Subscription, should get "Succeeded" state phase.

Sometimes could be, that it might take a bit longer to create all the resources and states within a CSV.

Add a condition check to CSV install check task to avoid such failures.