### PR TITLE
[ACM] - Fix CatalogSource check during ACM deploy

### DIFF
--- a/roles/acm/tasks/deploy.yml
+++ b/roles/acm/tasks/deploy.yml
@@ -63,8 +63,9 @@
     validate_certs: no
     api_version: operators.coreos.com/v1alpha1
     kind: CatalogSource
-    name: redhat-operators
-    namespace: openshift-marketplace
+    name: "{{ item.catalog_name }}"
+    namespace: "{{ item.catalog_ns }}"
+  loop: "{{ catalog_sources }}"
   register: acm_catalog
   until: acm_catalog.resources[0].status.connectionState.lastObservedState == "READY"
   retries: 15


### PR DESCRIPTION
During deploy of the ACM Hub, two CatalogSources created:
- acm-custom-catalog
- mce-custom-catalog

Make sure to check both CatalogSource for readiness after creation.