### PR TITLE
Update install reference to use the tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Name | Description
 
 Before using this collection, you need to install it with the Ansible Galaxy command-line tool:
 ```bash
-ansible-galaxy collection install git+https://github.com/stolostron/ansible-collection.rhacm.git,main
+ansible-galaxy collection install git+https://github.com/stolostron/ansible-collection.rhacm.git,0.0.1
 ```
 
 You can also include it in a `requirements.yml` file and install it with `ansible-galaxy collection install -r requirements.yml`, using the format:
@@ -25,7 +25,7 @@ You can also include it in a `requirements.yml` file and install it with `ansibl
 collections:
   - name: https://github.com/stolostron/ansible-collection.rhacm.git
     type: git
-    version: main
+    version: 0.0.1
 ```
 
 The `kubernetes` pip package needs to be installed as it required by some of the collection roles.  


### PR DESCRIPTION
Update install instructions within README to use tag instead of branch.