### PR TITLE
[ACM] - Fix CSV name fetch failure

### DIFF
--- a/roles/acm/tasks/deploy.yml
+++ b/roles/acm/tasks/deploy.yml
@@ -92,7 +92,10 @@
     name: acm-operator-subscription
     namespace: "{{ acm_namespace }}"
   register: acm_subscription
-  until: "'currentCSV' in acm_subscription.resources[0].status"
+  until:
+    - acm_subscription.resources | length > 0
+    - "'status' in acm_subscription.resources[0]"
+    - "'currentCSV' in acm_subscription.resources[0].status"
   retries: 15
   delay: 10
 


### PR DESCRIPTION
After creation of ACM Subscription, CSV resource created.
During the flow, we need to fetch the name of the CSV.
Creation of CSV resources and it's state could take some time.

Make sure to check for the states of CSV to prevent task failure.