### PR TITLE
[OCP] - Modify credentials structure in OCP role

### DIFF
--- a/docs/config-sample.yml
+++ b/docs/config-sample.yml
@@ -31,6 +31,7 @@ clusters:
   # AWS cluster
   - name: cluster1
     base_domain: <cluster_base_domain>
+    credentials: aws-creds
     network:
       cluster: 10.128.0.0/14
       machine: 10.0.0.0/16
@@ -40,11 +41,11 @@ clusters:
       platform: aws
       region: us-east-2
       instance_type: m5.xlarge
-    creds_type: aws
     openshift_version: "4.12"  # Optional. If not specified, will deploy the latest stable version
   # GCP cluster
   - name: cluster2
     base_domain: <cluster_base_domain>
+    credentials: gcp-creds
     network:
       cluster: 10.128.0.0/14
       machine: 10.0.0.0/16
@@ -55,10 +56,10 @@ clusters:
       region: us-east1
       instance_type: n1-standard-4
       project_id: gcp_project_name
-    creds_type: gcp
   # Openstack cluster
   - name: cluster3
     base_domain: example.com
+    credentials: openstack-creds
     network:
       cluster: 10.132.0.0/14
       machine: 10.0.0.0/16
@@ -70,17 +71,18 @@ clusters:
       external_network: <openstack_external_network>
       api_floating_ip: <apiFloatingIP>
       ingress_floating_ip: <ingressFloatingIP>
-    creds_type: openstack
     openshift_version: "4.13"
 
 clusters_credentials:
   # AWS credentials
-  aws:
+  - name: aws-creds
+    platform: aws
     aws_access_key_id: <aws_access_key_id>
     aws_secret_access_key: <aws_secret_access_key>
   # GCP credentials
   # Make sure to align each line
-  gcp:
+  - name: gcp-creds
+    platform: gcp
     os_service_account_json: |
       { "type": "service_account",
         "project_id": "...",
@@ -93,7 +95,8 @@ clusters_credentials:
         "auth_provider_x509_cert_url": "...",
         "client_x509_cert_url": "..." }
   # Openstack credentials
-  openstack:
+  - name: openstack-creds
+    platform: openstack
     auth_url: <openstack_api_url>
     username: <openstack_username>
     password: <openstack_password>

--- a/docs/ocp.md
+++ b/docs/ocp.md
@@ -62,6 +62,7 @@ clusters:
   # AWS cluster
   - name: test-cluster1
     base_domain: example.com
+    credentials: aws-creds
     network:
       cluster: 10.128.0.0/14
       machine: 10.0.0.0/16
@@ -71,13 +72,13 @@ clusters:
       platform: aws
       region: us-east-2
       instance_type: m5.xlarge
-    creds_type: aws
     openshift_version: "4.12"  # Optional variable to set OCP version per cluster
     fips: true  # Optional variable to enable FIPS on cluster
 
   # GCP cluster
   - name: test-cluster2
     base_domain: example.com
+    credentials: gcp-creds
     network:
       cluster: 10.128.0.0/14
       machine: 10.0.0.0/16
@@ -88,11 +89,11 @@ clusters:
       region: us-east1
       instance_type: n1-standard-4
       project_id: gcp_project_name
-    creds_type: gcp
 
   # Openstack cluster
   - name: test-cluster3
     base_domain: example.com
+    credentials: openstack-creds
     network:
       cluster: 10.132.0.0/14
       machine: 10.0.0.0/16
@@ -104,7 +105,6 @@ clusters:
       external_network: <openstack_external_network>
       api_floating_ip: <apiFloatingIP>
       ingress_floating_ip: <ingressFloatingIP>
-    creds_type: openstack
     openshift_version: "4.13"
 ```
 
@@ -113,19 +113,22 @@ Credentials that should be used during openshift cluster deployment
 ```
 clusters_credentials:
   # AWS credentials
-  aws:
+  - name: aws-creds
+    platform: aws
     aws_access_key_id: <your_key_id>
     aws_secret_access_key: <your_access_key>
 
   # GCP credentials
-  gcp:
+  - name: gcp-creds
+    platform: gcp
     os_service_account_json: |
       {
         ...content of osServiceAccount.json...
       }
 
   # Openstack credentials
-  openstack:
+  - name: openstack-creds
+    platform: openstack
     auth_url: <openstack_api_url>
     username: <openstack_username>
     password: <openstack_password>

--- a/roles/ocp/defaults/main.yml
+++ b/roles/ocp/defaults/main.yml
@@ -11,7 +11,7 @@ ssh_pub_key:
 clusters:
   - name: test-cluster
     base_domain: example.com
-    creds_type: aws
+    credentials: aws-creds
     network:
       cluster: 10.128.0.0/14
       machine: 10.0.0.0/16
@@ -24,7 +24,8 @@ clusters:
     openshift_version: "4.12"  # Optional variable to set OCP version per cluster
 
 clusters_credentials:
-  aws:
+  - name: aws-creds
+    platform: aws
     aws_access_key_id: <your_key>
     aws_secret_access_key: <your_secret_key>
 

--- a/roles/ocp/tasks/creds.yml
+++ b/roles/ocp/tasks/creds.yml
@@ -1,16 +1,16 @@
 ---
 - name: Sets credentails filename and path
   ansible.builtin.set_fact:
-    creds_path: "{%- if item.creds_type == 'aws' or item.creds_type == 'gcp' -%}
-                 {{ item.creds_type }}
-                 {%- elif item.creds_type == 'openstack' -%}
+    creds_path: "{%- if item.cloud.platform == 'aws' or item.cloud.platform == 'gcp' -%}
+                 {{ item.cloud.platform }}
+                 {%- elif item.cloud.platform == 'openstack' -%}
                  config/openstack
                  {%- endif -%}"
-    creds_file: "{%- if item.creds_type == 'aws' -%}
+    creds_file: "{%- if item.cloud.platform == 'aws' -%}
                  credentials
-                 {%- elif item.creds_type == 'gcp' -%}
+                 {%- elif item.cloud.platform == 'gcp' -%}
                  osServiceAccount.json
-                 {%- elif item.creds_type == 'openstack' -%}
+                 {%- elif item.cloud.platform == 'openstack' -%}
                  clouds.yaml
                  {%- endif -%}"
 

--- a/roles/ocp/templates/cloud-creds.j2
+++ b/roles/ocp/templates/cloud-creds.j2
@@ -1,20 +1,21 @@
-{% if item.creds_type == "aws" %}
+{% set creds = clusters_credentials | selectattr('name', 'equalto', item.credentials) | first %}
+{% if creds.platform == "aws" %}
 [default]
-aws_access_key_id = {{ clusters_credentials[item.creds_type].aws_access_key_id }}
-aws_secret_access_key = {{ clusters_credentials[item.creds_type].aws_secret_access_key }}
-{% elif item.creds_type == "gcp" %}
-{{ clusters_credentials[item.creds_type].os_service_account_json }}
-{% elif item.creds_type == "openstack" %}
+aws_access_key_id = {{ creds.aws_access_key_id }}
+aws_secret_access_key = {{ creds.aws_secret_access_key }}
+{% elif creds.platform == "gcp" %}
+{{ creds.os_service_account_json }}
+{% elif creds.platform == "openstack" %}
 clouds:
   openstack:
     auth:
-      auth_url: {{ clusters_credentials[item.creds_type].auth_url }}
-      username: "{{ clusters_credentials[item.creds_type].username }}"
-      password: "{{ clusters_credentials[item.creds_type].password }}"
-      project_id: "{{ clusters_credentials[item.creds_type].project_id }}"
-      project_name: "{{ clusters_credentials[item.creds_type].project_name }}"
-      user_domain_name: "{{ clusters_credentials[item.creds_type].domain_name }}"
-    region_name: "{{ clusters_credentials[item.creds_type].region_name | default('regionOne') }}"
-    interface: "{{ clusters_credentials[item.creds_type].interface | default('public') }}"
-    identity_api_version: {{ clusters_credentials[item.creds_type].api_version | default(3) }}
+      auth_url: {{ creds.auth_url }}
+      username: "{{ creds.username }}"
+      password: "{{ creds.password }}"
+      project_id: "{{ creds.project_id }}"
+      project_name: "{{ creds.project_name }}"
+      user_domain_name: "{{ creds.domain_name }}"
+    region_name: "{{ creds.region_name | default('regionOne') }}"
+    interface: "{{ creds.interface | default('public') }}"
+    identity_api_version: {{ creds.api_version | default(3) }}
 {% endif %}


### PR DESCRIPTION
Improve credentials structure in OCP role.
Current structure of credentials specify one single cluster per cloud platform.
```
aws:
  aws_access_key_id: <value>
  aws_secret_access_key: <value>
```

The new structure allows us to specify multiple credentials for the same cloud platform, so different clusters from the same platform are able to use separate credentials if needed.
```
- name: aws-creds
  platform: aws
  aws_access_key_id: <value>
  aws_secret_access_key: <value>
```