### PR TITLE
Add a task appending to existing creds file

### DIFF
--- a/roles/ocp/tasks/creds.yml
+++ b/roles/ocp/tasks/creds.yml
@@ -9,26 +9,28 @@
     creds_file: "{%- if item.cloud.platform == 'aws' -%}
                  credentials
                  {%- elif item.cloud.platform == 'gcp' -%}
-                 osServiceAccount.json
+                 gcp-service-account-rhacm-automation.json
                  {%- elif item.cloud.platform == 'openstack' -%}
                  clouds.yaml
                  {%- endif -%}"
 
-- name: Verify openshift cloud credentials
-  ansible.builtin.stat:
-    path: "{{ lookup('env', 'HOME') }}/{{ creds_path }}/{{ creds_file }}"
-  register: cloud_creds
+- name: Create platform creds directory
+  ansible.builtin.file:
+    path: "{{ lookup('env', 'HOME') }}/.{{ creds_path }}"
+    mode: 0755
+    state: directory
 
-- block:
-    - name: Create platform creds directory
-      ansible.builtin.file:
-        path: "{{ lookup('env', 'HOME') }}/.{{ creds_path }}"
-        mode: 0755
-        state: directory
+- name: Create cloud credentials file for GCP cloud
+  ansible.builtin.template:
+    src: cloud-creds.j2
+    dest: "{{ lookup('env', 'HOME') }}/.{{ creds_path }}/{{ creds_file }}"
+    mode: 0600
+  when: item.cloud.platform == 'gcp'
 
-    - name: Create cloud credentials file
-      ansible.builtin.template:
-        src: cloud-creds.j2
-        dest: "{{ lookup('env', 'HOME') }}/.{{ creds_path }}/{{ creds_file }}"
-        mode: 0600
-  when: not cloud_creds.stat.exists
+- name: Create cloud credentials file
+  ansible.builtin.blockinfile:
+    block: "{{ lookup('ansible.builtin.template', 'cloud-creds.j2') }}"
+    path: "{{ lookup('env', 'HOME') }}/.{{ creds_path }}/{{ creds_file }}"
+    create: yes
+    mode: 0600
+  when: item.cloud.platform != 'gcp'

--- a/roles/ocp/tasks/process.yml
+++ b/roles/ocp/tasks/process.yml
@@ -13,6 +13,9 @@
                       {%- else -%}
                       {{ openshift_channel }}
                       {%- endif -%}"
+  environment: 
+    AWS_PROFILE: 'rhacm-automation'
+    GOOGLE_APPLICATION_CREDENTIALS: "{{ lookup('env', 'HOME') }}/.gcp/gcp-service-account-rhacm-automation.json"
   ansible.builtin.command:
     cmd: "/tmp/openshift-install-{{ ocp_version_run }} {{ cluster_state }} cluster --dir {{ working_path }}/{{ item.name }}/"
   async: 3600

--- a/roles/ocp/templates/cloud-creds.j2
+++ b/roles/ocp/templates/cloud-creds.j2
@@ -1,13 +1,13 @@
 {% set creds = clusters_credentials | selectattr('name', 'equalto', item.credentials) | first %}
 {% if creds.platform == "aws" %}
-[default]
+[rhacm-automation]
 aws_access_key_id = {{ creds.aws_access_key_id }}
 aws_secret_access_key = {{ creds.aws_secret_access_key }}
 {% elif creds.platform == "gcp" %}
 {{ creds.os_service_account_json }}
 {% elif creds.platform == "openstack" %}
 clouds:
-  openstack:
+  rhacm-automation:
     auth:
       auth_url: {{ creds.auth_url }}
       username: "{{ creds.username }}"

--- a/roles/ocp/templates/install-config.yaml.j2
+++ b/roles/ocp/templates/install-config.yaml.j2
@@ -44,7 +44,7 @@ platform:
     projectID: {{ item.cloud.project_id }}
 {% elif item.cloud.platform == "openstack" %}
   {{ item.cloud.platform }}:
-    cloud: openstack
+    cloud: rhacm-automation
     externalNetwork: {{ item.cloud.external_network }}
     apiFloatingIP: {{ item.cloud.api_floating_ip }}
     ingressFloatingIP: {{ item.cloud.ingress_floating_ip }}


### PR DESCRIPTION
When a creds file already exists, the role will append the new credentials to the end of this file. 
When there is no creds file, the role will create a new one. 
In addition fix the path to the cred_file.