### PR TITLE
[MANAGED_OPENSHIFT] - Unify automation account in aro flow

### DIFF
--- a/plugins/modules/azure_rm_openshiftmanagedcluster_kubeconfig_info.py
+++ b/plugins/modules/azure_rm_openshiftmanagedcluster_kubeconfig_info.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: azure_rm_openshiftmanagedcluster_kubeconfig_info
-version_added: '1.16.0'
+version_added: '1.17.0'
 short_description: Get admin kubeconfig of Azure Red Hat OpenShift Managed Cluster
 description:
     - get kubeconfig of Azure Red Hat OpenShift Managed Cluster instance.
@@ -187,7 +187,8 @@ class AzureRMOpenShiftManagedClustersKubeconfigInfo(AzureRMModuleBaseExt):
             file_name = os.path.basename(self.path)
             path = self.path.replace(file_name, '')
             self.log('Checking path {0}'. format(path))
-            if not os.path.isdir(path):
+            # If the "path" is not defined, it's cwd.
+            if path and not os.path.isdir(path):
                 try:
                     self.log('Attempting to makedirs {0}'. format(path))
                     os.makedirs(path)

--- a/roles/managed_openshift/tasks/aro/check_cluster.yml
+++ b/roles/managed_openshift/tasks/aro/check_cluster.yml
@@ -5,7 +5,7 @@
 
 - name: ARO - Check if ARO cluster exists
   azure.azcollection.azure_rm_openshiftmanagedcluster_info:
-    profile: rhacm-aro
+    profile: rhacm-automation
     name: "{{ item.name }}"
     resource_group: "{{ item.name }}-rg"
   register: aro_cluster_state

--- a/roles/managed_openshift/tasks/aro/delete.yml
+++ b/roles/managed_openshift/tasks/aro/delete.yml
@@ -9,7 +9,7 @@
 
 - name: ARO - Delete OpenShift Managed Cluster
   azure.azcollection.azure_rm_openshiftmanagedcluster:
-    profile: rhacm-aro
+    profile: rhacm-automation
     name: "{{ item.name }}"
     resource_group: "{{ item.name }}-rg"
     location: "{{ item.region }}"
@@ -17,7 +17,7 @@
 
 - name: ARO - Delete resource group
   azure.azcollection.azure_rm_resourcegroup:
-    profile: rhacm-aro
+    profile: rhacm-automation
     name: "{{ item.name }}-rg"
     location: "{{ item.region }}"
     state: absent

--- a/roles/managed_openshift/tasks/aro/dns_records.yml
+++ b/roles/managed_openshift/tasks/aro/dns_records.yml
@@ -6,7 +6,7 @@
 
 - name: ARO - DNS record for cluster API and APPS
   azure.azcollection.azure_rm_dnsrecordset:
-    profile: rhacm-aro
+    profile: rhacm-automation
     relative_name: "{{ entry.name }}.{{ item.name }}"
     resource_group: "{{ item.resource_group_name }}"
     zone_name: "{{ item.base_domain }}"

--- a/roles/managed_openshift/tasks/aro/fetch_connection_details.yml
+++ b/roles/managed_openshift/tasks/aro/fetch_connection_details.yml
@@ -1,7 +1,7 @@
 ---
 - name: ARO - Fetch cluster kubeconfig file
   azure_rm_openshiftmanagedcluster_kubeconfig_info:
-    profile: rhacm-aro
+    profile: rhacm-automation
     name: "{{ item.name }}"
     resource_group: "{{ item.name }}-rg"
     path: "{{ working_path }}/{{ item.name }}/kubeconfig"
@@ -9,13 +9,14 @@
 
 - name: ARO - Fetch ARO cluster admin credentials
   azure_rm_openshiftmanagedcluster_credentials_info:
-    profile: rhacm-aro
+    profile: rhacm-automation
     name: "{{ item.name }}"
     resource_group: "{{ item.name }}-rg"
   register: cl_creds
   no_log: true
 
-- ansible.builtin.copy:
+- name: ARO - Create kubeadmin-credentials file
+  ansible.builtin.copy:
     content: |
       username: {{ cl_creds['credentials']['kubeadminUsername'] }}
       password: {{ cl_creds['credentials']['kubeadminPassword'] }}

--- a/roles/managed_openshift/tasks/aro/prerequisites.yml
+++ b/roles/managed_openshift/tasks/aro/prerequisites.yml
@@ -4,30 +4,16 @@
     subscription: "{{ managed_openshift_clusters_credentials
       | selectattr('name', 'equalto', item.credentials) | first }}"
 
-- name: Set credentials filename and path
-  ansible.builtin.set_fact:
-    creds_path: "{%- if item.platform == 'aro' -%}
-                 azure
-                 {%- endif -%}"
-    creds_file: "{%- if item.platform == 'aro' -%}
-                 credentials
-                 {%- endif -%}"
-
-- name: Create platform credentials directory
+- name: ARO - Create platform credentials directory
   ansible.builtin.file:
-    path: "{{ lookup('env', 'HOME') }}/.{{ creds_path }}"
+    path: "{{ lookup('env', 'HOME') }}/.azure"
     mode: 0755
     state: directory
 
-- name: Create account credentials file
+- name: ARO - Create account credentials file
   ansible.builtin.blockinfile:
-    path: "{{ lookup('env', 'HOME') }}/.{{ creds_path }}/{{ creds_file }}"
-    block: |
-      [rhacm-aro]
-      subscription_id={{ subscription.subscription_id }}
-      client_id={{ subscription.client_id }}
-      secret={{ subscription.client_secret }}
-      tenant={{ subscription.tenant_id }}
-    marker: "#{mark} rhacm-aro credentials"
+    path: "{{ lookup('env', 'HOME') }}/.azure/credentials"
+    block: "{{ lookup('ansible.builtin.template', 'cloud-creds.j2') }}"
+    marker: "#{mark} rhacm-automation"
     create: true
     state: present

--- a/roles/managed_openshift/tasks/aro/process.yml
+++ b/roles/managed_openshift/tasks/aro/process.yml
@@ -1,7 +1,7 @@
 ---
 - name: ARO - Create resource group
   azure.azcollection.azure_rm_resourcegroup:
-    profile: rhacm-aro
+    profile: rhacm-automation
     name: "{{ item.name }}-rg"
     location: "{{ item.region }}"
     state: present
@@ -10,7 +10,7 @@
 
 - name: ARO - Create virtual network
   azure.azcollection.azure_rm_virtualnetwork:
-    profile: rhacm-aro
+    profile: rhacm-automation
     name: "{{ item.name }}-vnet"
     resource_group: "{{ item.name }}-rg"
     location: "{{ item.region }}"
@@ -20,7 +20,7 @@
 
 - name: ARO - Create subnet for Masters
   azure.azcollection.azure_rm_subnet:
-    profile: rhacm-aro
+    profile: rhacm-automation
     name: "master-subnet"
     resource_group: "{{ item.name }}-rg"
     virtual_network_name: "{{ item.name }}-vnet"
@@ -34,7 +34,7 @@
 
 - name: ARO - Create subnet for Worker
   azure.azcollection.azure_rm_subnet:
-    profile: rhacm-aro
+    profile: rhacm-automation
     name: "worker-subnet"
     resource_group: "{{ item.name }}-rg"
     virtual_network_name: "{{ item.name }}-vnet"
@@ -52,14 +52,14 @@
 
 - name: ARO - Create cluster
   azure.azcollection.azure_rm_openshiftmanagedcluster:
-    profile: rhacm-aro
+    profile: rhacm-automation
     name: "{{ item.name }}"
     resource_group: "{{ item.name }}-rg"
     location: "{{ item.region }}"
     cluster_profile:
       domain: "{{ item.name }}.{{ item.base_domain }}"
       pull_secret: "{{ pull_secret | string }}"
-      version: "{{ item.cluster_version | default(omit) }}"
+      version: "{{ item.openshift_version | default(omit) }}"
     service_principal_profile:
       client_id: "{{ app_id }}"
       client_secret: "{{ subscription.client_secret }}"

--- a/roles/managed_openshift/tasks/aro/rbac.yml
+++ b/roles/managed_openshift/tasks/aro/rbac.yml
@@ -5,7 +5,7 @@
 
 - name: ARO - Recheck the AD app if was created
   azure.azcollection.azure_rm_adapplication_info:
-    profile: rhacm-aro
+    profile: rhacm-automation
     tenant: "{{ subscription.tenant_id }}"
   register: ad_app
   no_log: true
@@ -21,7 +21,7 @@
 
 - name: ARO - Create AD Service Principal
   azure.azcollection.azure_rm_adserviceprincipal:
-    profile: rhacm-aro
+    profile: rhacm-automation
     tenant: "{{ subscription.tenant_id }}"
     app_id: "{{ app_id }}"
     state: present
@@ -34,7 +34,7 @@
 
 - name: ARO - Fetch the AD Service Principal info
   azure.azcollection.azure_rm_adserviceprincipal_info:
-    profile: rhacm-aro
+    profile: rhacm-automation
     tenant: "{{ subscription.tenant_id }}"
     app_id: "{{ app_id }}"
   register: ad_sp
@@ -45,7 +45,7 @@
 
 - name: ARO - Set AD app password
   azure.azcollection.azure_rm_adpassword:
-    profile: rhacm-aro
+    profile: rhacm-automation
     tenant: "{{ subscription.tenant_id }}"
     app_id: "{{ app_id }}"
     value: "{{ subscription.client_secret }}"
@@ -54,7 +54,7 @@
 
 - name: ARO - Fetch ARO Resource Group Contributor Role Definition Scope
   azure.azcollection.azure_rm_roledefinition_info:
-    profile: rhacm-aro
+    profile: rhacm-automation
     scope: "/subscriptions/{{ subscription.subscription_id }}"
   register: rg_contrib_role_scope
   no_log: true
@@ -68,7 +68,7 @@
 
 - name: ARO - Set ARO Subscription Contributor Role to the Service Principal
   azure.azcollection.azure_rm_roleassignment:
-    profile: rhacm-aro
+    profile: rhacm-automation
     subscription_id: "{{ subscription.subscription_id }}"
     tenant: "{{ subscription.tenant_id }}"
     scope: "/subscriptions/{{ subscription.subscription_id }}"
@@ -77,7 +77,7 @@
 
 - name: ARO - Fetch ARO Resource Group Network Contributor Role Definition Scope
   azure.azcollection.azure_rm_roledefinition_info:
-    profile: rhacm-aro
+    profile: rhacm-automation
     scope: "/subscriptions/{{ subscription.subscription_id }}/resourceGroups/{{ item.name }}-rg"
   register: rg_net_contrib_role_scope
   no_log: true
@@ -93,7 +93,7 @@
 # https://github.com/ansible-collections/azure/pull/901
 - name: ARO - Fetch AD Service Principal info
   azure_rm_adserviceprincipal_info:
-    profile: rhacm-aro
+    profile: rhacm-automation
     tenant: "{{ subscription.tenant_id }}"
     app_display_name: "Azure Red Hat OpenShift RP"
   register: aro_ad_sp
@@ -104,7 +104,7 @@
 
 - name: ARO - Granting Resource Provider Contributor access to the ARO virtual network
   azure.azcollection.azure_rm_roleassignment:
-    profile: rhacm-aro
+    profile: rhacm-automation
     scope: "/subscriptions/{{ subscription.subscription_id }}/resourceGroups/{{ item.name }}-rg/providers/Microsoft.Network/virtualNetworks/{{ item.name }}-vnet"
     assignee_object_id: "{{ aro_sp_object_id }}"
     role_definition_id: "{{ rg_net_contrib_object_id }}"

--- a/roles/managed_openshift/tasks/aro/rbac_app_and_sp.yml
+++ b/roles/managed_openshift/tasks/aro/rbac_app_and_sp.yml
@@ -2,6 +2,7 @@
   ansible.builtin.set_fact:
     subscription: "{{ managed_openshift_clusters_credentials
       | selectattr('name', 'equalto', item.credentials) | first }}"
+  no_log: true
 
 - name: ARO - Set AD application display name and define a password
   ansible.builtin.set_fact:
@@ -9,7 +10,7 @@
 
 - name: ARO - Check of AD app already exists
   azure.azcollection.azure_rm_adapplication_info:
-    profile: rhacm-aro
+    profile: rhacm-automation
     tenant: "{{ subscription.tenant_id }}"
   register: ad_app
   no_log: true
@@ -23,7 +24,7 @@
 
 - name: ARO - AD application - {{ state }}
   azure.azcollection.azure_rm_adapplication:
-    profile: rhacm-aro
+    profile: rhacm-automation
     display_name: "{{ app_display_name }}"
     tenant: "{{ subscription.tenant_id }}"
     app_id: "{{ ad_state if state == 'absent' else omit }}"

--- a/roles/managed_openshift/tasks/aro/wait_for_cluster.yml
+++ b/roles/managed_openshift/tasks/aro/wait_for_cluster.yml
@@ -1,7 +1,7 @@
 ---
 - name: ARO - Wait for cluster provisioning to complete
   azure.azcollection.azure_rm_openshiftmanagedcluster_info:
-    profile: rhacm-aro
+    profile: rhacm-automation
     name: "{{ item.name }}"
     resource_group: "{{ item.name }}-rg"
   register: aro_cluster_state


### PR DESCRIPTION
Unify automation account name to be used accross all collection.
Account name will be - "rhacm-automation".

Update ARO flow to use that automation account name.