### PR TITLE
Add new role - acm_import_cluster

### DIFF
--- a/docs/acm_import_cluster.md
+++ b/docs/acm_import_cluster.md
@@ -1,0 +1,53 @@
+# ACM Import Cluster
+
+## Description
+The `acm_import_cluster` role imports or detaches Openshift clusters into ACM Hub.
+
+## Role default variables
+#### State of the cluster
+Create or destroy the cluster.  
+The state could be 'present' or 'absent'.
+```
+state: present
+```
+
+#### Clusters to import
+List of clusters to be imported into the ACM Hub.  
+**Note 1** - By default, cluster name specified here will be searched across clusters deployed by `ocp` and `managed_openshift` roles.  
+Once found, it will search for kubeconfig of that cluster and will use it during the import of the cluster into the Hub.  
+**Note 2** - The `kubeconfig` parameter is optional. It should be used only when a cluster was not created by the `ocp` or `managed_openshift` roles.
+**Note 3** - The `cloud_creds` parameter is optional. Specify it if cloud credentials of the cluster should be created in Hub.  
+Will search credentials under `ocp` role credentials variable - `clusters_credentials`
+```
+acm_import_clusters:
+  - name: cluster1
+
+  - name: cluster2
+    # Optional. Apply cloud credentials.
+    # Taken from "clusters_credentials" var of "OCP" role.
+    cloud_creds: aws-creds
+
+  - name: cluster3
+    # Optional. Define addon flags per each cluster.
+    application_manager: false
+    argocd: false
+    policy_controller: true
+    search_collector: true
+    cert_policy_controller: false
+    iam_policy_controller: true
+
+  - name: cluster4
+    # Optional. Specify kubeconfig if cluster was not deployed by `ocp` or `managed_openshift` roles
+    kubeconfig: /path/to/kubeconfig
+```
+
+#### Import cluster global addon flags
+Define addon flags for all imported clusters.
+```
+acm_import_cluster_application_manager: true
+acm_import_cluster_argocd: false
+acm_import_cluster_policy_controller: true
+acm_import_cluster_search_collector: true
+acm_import_cluster_cert_policy_controller: true
+acm_import_cluster_iam_policy_controller: true
+```

--- a/docs/config-sample.yml
+++ b/docs/config-sample.yml
@@ -293,3 +293,28 @@ managed_openshift_clusters_credentials:
     client_secret: <client_secret>
     tenant_id: <tenant_id>
     subscription_id: <subscription_id>
+
+##########################
+# ACM IMPORT CLUSTER role
+##########################
+
+acm_import_clusters:
+  - name: cluster1
+
+  - name: cluster2
+    # Optional. Apply cloud credentials.
+    # Taken from "clusters_credentials" var of "OCP" role.
+    cloud_creds: aws-creds
+
+  - name: cluster3
+    # Optional. Define addon flags per each cluster.
+    application_manager: false
+    argocd: false
+    policy_controller: true
+    search_collector: true
+    cert_policy_controller: false
+    iam_policy_controller: true
+
+  - name: cluster4
+    # Optional. Specify kubeconfig if cluster was not deployed by `ocp` or `managed_openshift` roles
+    kubeconfig: /path/to/kubeconfig

--- a/roles/acm_import_cluster/README.md
+++ b/roles/acm_import_cluster/README.md
@@ -1,0 +1,3 @@
+# ACM Import Cluster
+
+Role documentation could be found in the following link - [docs](../../docs/acm_import_cluster.md)

--- a/roles/acm_import_cluster/defaults/main.yml
+++ b/roles/acm_import_cluster/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+state: present
+
+acm_import_clusters:
+  #- name: cluster1
+
+# Import cluster global addon flags
+acm_import_cluster_application_manager: true
+acm_import_cluster_argocd: false
+acm_import_cluster_policy_controller: true
+acm_import_cluster_search_collector: true
+acm_import_cluster_cert_policy_controller: true
+acm_import_cluster_iam_policy_controller: true

--- a/roles/acm_import_cluster/tasks/handle_import_secret.yml
+++ b/roles/acm_import_cluster/tasks/handle_import_secret.yml
@@ -1,0 +1,35 @@
+---
+- name: Fetch cluster import secret
+  kubernetes.core.k8s_info:
+    host: "{{ cluster_api }}"
+    api_key: "{{ cluster_api_token }}"
+    validate_certs: no
+    api_version: v1
+    kind: Secret
+    name: "{{ item.name }}-import"
+    namespace: "{{ item.name }}"
+  register: import_secret
+  no_log: true
+
+- name: Locate crds.yaml secret
+  ansible.builtin.set_fact:
+    crds_secret: "{{ import_secret.resources[0].data['crds.yaml'] }}"
+  no_log: true
+
+- name: Locate import.yaml secret
+  ansible.builtin.set_fact:
+    import_secret: "{{ import_secret.resources[0].data['import.yaml'] }}"
+  no_log: true
+
+- name: Apply crds and import secret into the cluster
+  community.okd.k8s:
+    kubeconfig: "{{ item.kubeconfig }}"
+    definition: "{{ secret | b64decode }}"
+    validate_certs: no
+    state: "present"
+  loop:
+    - "{{ crds_secret }}"
+    - "{{ import_secret }}"
+  loop_control:
+    loop_var: secret
+  no_log: true

--- a/roles/acm_import_cluster/tasks/locate_kubeconfig_file.yml
+++ b/roles/acm_import_cluster/tasks/locate_kubeconfig_file.yml
@@ -1,0 +1,24 @@
+---
+- name: Set current path
+  ansible.builtin.set_fact:
+    working_path: "{{ lookup('env', 'PWD') }}"
+
+- name: Validate kubeconfig file existence
+  ansible.builtin.stat:
+    path: "{{ working_path }}/{{ dir }}/{{ item.name }}/kubeconfig"
+  loop:
+    - "{{ ocp_assets_dir }}"
+    - "{{ managed_openshift_dir }}"
+  loop_control:
+    loop_var: dir
+  register: dir_stat
+
+- name: Append kubeconfig path to a cluster entry
+  ansible.builtin.set_fact:
+    updated_clusters_to_import_list: "{{ updated_clusters_to_import_list | default([])
+      + [item | combine({ 'kubeconfig': (item.kubeconfig | default('')
+      + kubeconf_item.stat.path) | trim })] }}"
+  loop: "{{ dir_stat.results }}"
+  loop_control:
+    loop_var: kubeconf_item
+  when: kubeconf_item.stat.exists

--- a/roles/acm_import_cluster/tasks/main.yml
+++ b/roles/acm_import_cluster/tasks/main.yml
@@ -1,0 +1,76 @@
+---
+- name: Generate cluster token for authentication
+  ansible.builtin.include_role:
+    name: cluster_login
+
+- name: Check for already imported clusters
+  kubernetes.core.k8s_info:
+    host: "{{ cluster_api }}"
+    api_key: "{{ cluster_api_token }}"
+    validate_certs: no
+    api_version: cluster.open-cluster-management.io/v1
+    kind: ManagedCluster
+    name: "{{ item.name }}"
+  loop: "{{ acm_import_clusters }}"
+  register: managed_clusters_state
+
+# Init clusters_to_import var so in case no clusters found to be imported
+# the flow just skip all tasks and not fail.
+- name: Init clusters_to_import var
+  ansible.builtin.set_fact:
+    clusters_to_import: []
+
+- name: Create clusters list to be imported
+  ansible.builtin.set_fact:
+    clusters_to_import: "{{ clusters_to_import | default([]) + [ item.item ] }}"
+  loop: "{{ managed_clusters_state.results }}"
+  when:
+    - state == "present"
+    - item.resources | length == 0
+
+- name: Create clusters list to be detached
+  ansible.builtin.set_fact:
+    clusters_to_import: "{{ clusters_to_import | default([]) + [ item.item ] }}"
+  loop: "{{ managed_clusters_state.results }}"
+  when:
+    - state == "absent"
+    - item.resources | length != 0
+
+- name: Process ManagedCluster for cluster import
+  community.okd.k8s:
+    host: "{{ cluster_api }}"
+    api_key: "{{ cluster_api_token }}"
+    validate_certs: no
+    definition: "{{ lookup('template', 'managed-cluster.yaml.j2') | from_yaml }}"
+    state: "{{ state }}"
+  loop: "{{ clusters_to_import }}"
+
+- name: Process import
+  ansible.builtin.include_tasks:
+    file: process_import.yml
+  when: state == "present"
+
+- name: Check for imported cluster to be detached
+  kubernetes.core.k8s_info:
+    host: "{{ cluster_api }}"
+    api_key: "{{ cluster_api_token }}"
+    validate_certs: no
+    api_version: cluster.open-cluster-management.io/v1
+    kind: ManagedCluster
+    name: "{{ item.name }}"
+  loop: "{{ clusters_to_import }}"
+  register: remove_clusters
+  until: remove_clusters.resources | length == 0
+  retries: 25
+  delay: 15
+  when: state == "absent"
+
+- name: Print state message
+  vars:
+    import_state: "{%- if state == 'present' -%}
+                   imported
+                   {%- elif state == 'absent' -%}
+                   detached
+                   {%- endif -%}"
+  ansible.builtin.debug:
+    msg: "The clusters have been {{ import_state }}"

--- a/roles/acm_import_cluster/tasks/process_import.yml
+++ b/roles/acm_import_cluster/tasks/process_import.yml
@@ -1,0 +1,81 @@
+---
+# Init clusters_to_import var so in case no clusters found to be imported
+# the flow just skip all tasks and not fail.
+- name: Init clusters_to_import var
+  ansible.builtin.set_fact:
+    updated_clusters_to_import_list: []
+
+- name: Locate kubeconfig file for clusters (when not explicitly defined)
+  ansible.builtin.include_tasks:
+    file: locate_kubeconfig_file.yml
+  loop: "{{ clusters_to_import }}"
+  when: item.kubeconfig is not defined
+
+- name: Update clusters import list
+  ansible.builtin.set_fact:
+    clusters_to_import: "{{ [clusters_to_import, updated_clusters_to_import_list]
+      | community.general.lists_mergeby('name', list_merge='replace') }}"
+
+- name: Create KlusterletAddonConfig for cluster import
+  community.okd.k8s:
+    host: "{{ cluster_api }}"
+    api_key: "{{ cluster_api_token }}"
+    validate_certs: no
+    definition: "{{ lookup('template', 'klusterlet-addon-config.yaml.j2') | from_yaml }}"
+    state: present
+  loop: "{{ clusters_to_import }}"
+
+- name: Handle clusters import secret
+  ansible.builtin.include_tasks:
+    file: handle_import_secret.yml
+  loop: "{{ clusters_to_import }}"
+
+- name: Wait for import cluster to join
+  kubernetes.core.k8s_info:
+    host: "{{ cluster_api }}"
+    api_key: "{{ cluster_api_token }}"
+    validate_certs: no
+    api_version: cluster.open-cluster-management.io/v1
+    kind: ManagedCluster
+    name: "{{ item.name }}"
+    wait: yes
+    wait_timeout: 900
+    wait_condition:
+      type: ManagedClusterJoined
+      status: True
+  loop: "{{ clusters_to_import }}"
+
+- name: Wait for import cluster to become available
+  kubernetes.core.k8s_info:
+    host: "{{ cluster_api }}"
+    api_key: "{{ cluster_api_token }}"
+    validate_certs: no
+    api_version: cluster.open-cluster-management.io/v1
+    kind: ManagedCluster
+    name: "{{ item.name }}"
+    wait: yes
+    wait_timeout: 900
+    wait_condition:
+      type: ManagedClusterConditionAvailable
+      status: True
+  loop: "{{ clusters_to_import }}"
+
+- name: Add cluster kubeconfig file to the hub
+  community.okd.k8s:
+    host: "{{ cluster_api }}"
+    api_key: "{{ cluster_api_token }}"
+    validate_certs: no
+    definition: "{{ lookup('template', 'kubeconfig-secret.yaml.j2') | from_yaml }}"
+    state: present
+  loop: "{{ clusters_to_import }}"
+  no_log: true
+
+- name: Add cluster cloud credential secret to the hub (if defined)
+  community.okd.k8s:
+    host: "{{ cluster_api }}"
+    api_key: "{{ cluster_api_token }}"
+    validate_certs: no
+    definition: "{{ lookup('template', 'cloud-secret.yaml.j2') | from_yaml }}"
+    state: present
+  loop: "{{ clusters_to_import }}"
+  when: item.cloud_creds is defined

--- a/roles/acm_import_cluster/templates/cloud-secret.yaml.j2
+++ b/roles/acm_import_cluster/templates/cloud-secret.yaml.j2
@@ -1,0 +1,25 @@
+{% set creds = clusters_credentials | selectattr('name', 'equalto', item.cloud_creds) | first %}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ item.name }}-{{ creds.name }}
+  namespace: {{ item.name }}
+type: Opaque
+data:
+{% if creds.platform == "aws" %}
+  aws_access_key_id: {{ creds.aws_access_key_id | b64encode }}
+  aws_secret_access_key: {{ creds.aws_secret_access_key | b64encode }}
+{% elif creds.platform == "gcp" %}
+  projectID: {{ creds.project_id | b64encode }}
+  osServiceAccount.json: {{ creds.os_service_account_json | b64encode }}
+{% elif creds.platform == "azr" %}
+  baseDomainResourceGroupName: {{ creds.base_domain_resource_group_name | b64encode }}
+  cloudName: {{ creds.cloud_name | b64encode }}
+  osServicePrincipal.json: {{ creds.os_service_principal_json | b64encode }}
+{% elif creds.platform == "vmw" %}
+  username: {{ creds.username | b64encode }}
+  password: {{ creds.password | b64encode }}
+{% elif creds.platform == "openstack" %}
+  cloud: {{ 'openstack' | b64encode }}
+  clouds.yaml: {{ lookup('template', 'clouds.yaml.j2') | b64encode }}
+{% endif %}

--- a/roles/acm_import_cluster/templates/clouds.yaml.j2
+++ b/roles/acm_import_cluster/templates/clouds.yaml.j2
@@ -1,0 +1,15 @@
+{% if item.cloud_creds is defined %}
+{% set creds = clusters_credentials | selectattr('name', 'equalto', item.cloud_creds) | first %}
+{% endif %}
+clouds:
+  openstack:
+    auth:
+      auth_url: {{ item.auth_url | default(creds.auth_url) }}
+      username: "{{ item.username | default(creds.username) }}"
+      password: "{{ item.password | default(creds.password) }}"
+      project_id: "{{ item.project_id | default(creds.project_id) }}"
+      project_name: "{{ item.project_name | default(creds.project_name) }}"
+      user_domain_name: "{{ item.domain_name | default(creds.domain_name) }}"
+    region_name: "{{ item.region_name | default(creds.region_name | default('regionOne')) }}"
+    interface: "{{ item.interface | default(creds.interface | default('public')) }}"
+    identity_api_version: {{ item.api_version | default(creds.api_version | default(3)) }}

--- a/roles/acm_import_cluster/templates/klusterlet-addon-config.yaml.j2
+++ b/roles/acm_import_cluster/templates/klusterlet-addon-config.yaml.j2
@@ -1,0 +1,23 @@
+apiVersion: agent.open-cluster-management.io/v1
+kind: KlusterletAddonConfig
+metadata:
+  name: {{ item.name }}
+  namespace: {{ item.name }}
+spec:
+  clusterName: {{ item.name }}
+  clusterNamespace: {{ item.name }}
+  clusterLabels:
+    name: {{ item.name }}
+    cloud: auto-detect
+    vendor: auto-detect
+  applicationManager:
+    enabled: {{ item.application_manager | default(acm_import_cluster_application_manager) }}
+    argocdCluster: {{ item.argocd | default(acm_import_cluster_argocd) }}
+  policyController:
+    enabled: {{ item.policy_controller | default(acm_import_cluster_policy_controller) }}
+  searchCollector:
+    enabled: {{ item.search_collector | default(acm_import_cluster_search_collector) }}
+  certPolicyController:
+    enabled: {{ item.cert_policy_controller | default(acm_import_cluster_cert_policy_controller) }}
+  iamPolicyController:
+    enabled: {{ item.iam_policy_controller | default(acm_import_cluster_iam_policy_controller) }}

--- a/roles/acm_import_cluster/templates/kubeconfig-secret.yaml.j2
+++ b/roles/acm_import_cluster/templates/kubeconfig-secret.yaml.j2
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ item.name }}-0-admin-kubeconfig
+  namespace: {{ item.name }}
+type: Opaque
+data:
+  kubeconfig: {{ lookup('file', '{{ item.kubeconfig }}') | b64encode }}
+  raw-kubeconfig: {{ lookup('file', '{{ item.kubeconfig }}') | b64encode }}

--- a/roles/acm_import_cluster/templates/managed-cluster.yaml.j2
+++ b/roles/acm_import_cluster/templates/managed-cluster.yaml.j2
@@ -1,0 +1,11 @@
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  name: {{ item.name }}
+  labels:
+    name: {{ item.name }}
+    cloud: auto-detect
+    vendor: auto-detect
+  annotations: {}
+spec:
+  hubAcceptsClient: true

--- a/roles/acm_import_cluster/vars/main.yml
+++ b/roles/acm_import_cluster/vars/main.yml
@@ -1,0 +1,3 @@
+---
+ocp_assets_dir: logs/ocp_assets
+managed_openshift_dir: logs/managed_openshift


### PR DESCRIPTION
The new "acm_import_cluster" roles will allow to import / detach clusters deployed by using "ocp" or "managed_openshift" roles or manually.