### PR TITLE
[Cluster Login] - Update cluster login var name

### DIFF
--- a/docs/cluster_login.md
+++ b/docs/cluster_login.md
@@ -18,11 +18,11 @@ The role is able to work in one of the following states:
   ```
 
 ## Role Variables
-#### Cluster name
+#### Cluster login name
 Specify the name of the cluster to generate the login token for.  
 If the variable is not defined, the first cluster from the details file will be taken.
 ```
-cluster_name
+cluster_login_name
 ```
 
 #### Clusters details file

--- a/roles/cluster_login/defaults/main.yml
+++ b/roles/cluster_login/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-cluster_name:
+cluster_login_name:
 
 clusters_details_file: clusters_details.yml
 ocp_assets_dir: logs/ocp_assets

--- a/roles/cluster_login/tasks/main.yml
+++ b/roles/cluster_login/tasks/main.yml
@@ -16,8 +16,8 @@
 
     - name: Set the hub to use if defined or first available
       ansible.builtin.set_fact:
-        cl_name: "{%- if cluster_name -%}
-                  {{ hub_name }}
+        cl_name: "{%- if cluster_login_name -%}
+                  {{ cluster_login_name }}
                   {%- else -%}
                   {{ cl_file | first }}
                   {%- endif -%}"


### PR DESCRIPTION
The "cluster_login" role generates a token from the cluster for later use.
By default, cluster details taken from the first cluster within the "clusters_details.yml" file.
It's possible to define specific cluster to be used.

Update the var for that cluster to - cluster_login_name