### PR TITLE
[Managed Openshift] - Add missing "region" to rosa commands

### DIFF
--- a/roles/managed_openshift/tasks/aro/fetch_connection_details.yml
+++ b/roles/managed_openshift/tasks/aro/fetch_connection_details.yml
@@ -25,7 +25,7 @@
 
 - name: ARO - Fetch cluster URLs
   azure.azcollection.azure_rm_openshiftmanagedcluster_info:
-    profile: rhacm-aro
+    profile: rhacm-automation
     name: "{{ item.name }}"
     resource_group: "{{ item.name }}-rg"
   register: aro_cluster_urls

--- a/roles/managed_openshift/tasks/rosa/fetch_connection_details.yml
+++ b/roles/managed_openshift/tasks/rosa/fetch_connection_details.yml
@@ -1,7 +1,12 @@
 ---
 - name: ROSA - Fetch cluster api and console urls
   ansible.builtin.command:
-    cmd: "{{ rosa }} --profile rhacm-automation describe cluster --cluster {{ item.name }} -o json"
+    cmd: |
+      {{ rosa }} --profile rhacm-automation
+      describe cluster
+      --cluster {{ item.name }}
+      --region {{ item.region }}
+      -o json
   register: rosa_cluster_url
 
 # Admin user for ROSA cluster created once and in order to fetch its password again
@@ -9,17 +14,32 @@
 - block:
     - name: ROSA - Create admin user
       ansible.builtin.command:
-        cmd: "{{ rosa }} --profile rhacm-automation create admin --cluster {{ item.name }} -o json"
+        cmd: |
+          {{ rosa }} --profile rhacm-automation
+          create admin
+          --cluster {{ item.name }}
+          --region {{ item.region }}
+          -o json
       register: rosa_admin
       no_log: true
   rescue:
     - name: ROSA - Delete existing admin user
       ansible.builtin.command:
-        cmd: "{{ rosa }} --profile rhacm-automation delete admin --cluster {{ item.name }} --yes"
+        cmd: |
+          {{ rosa }} --profile rhacm-automation
+          delete admin
+          --cluster {{ item.name }}
+          --region {{ item.region }}
+          --yes
 
     - name: ROSA - Create admin user
       ansible.builtin.command:
-        cmd: "{{ rosa }} --profile rhacm-automation create admin --cluster {{ item.name }} -o json"
+        cmd: |
+          {{ rosa }} --profile rhacm-automation
+          create admin
+          --cluster {{ item.name }}
+          --region {{ item.region }}
+          -o json
       register: rosa_admin
       no_log: true
 


### PR DESCRIPTION
Add "region" argument to rosa commands that was missed in the previous patch.