### PR TITLE
[Ocp] - Copy kubeconfig file to cluster root dir

### DIFF
--- a/roles/ocp/tasks/fetch_details.yml
+++ b/roles/ocp/tasks/fetch_details.yml
@@ -32,6 +32,12 @@
     cluster_pass: "{{ cluster_pass_reg['content'] | b64decode }}"
   no_log: true
 
+- name: Copy kubeconfig file to root of cluster directory
+  ansible.builtin.copy:
+    src: "{{ working_path }}/{{ item.name }}/auth/kubeconfig"
+    dest: "{{ working_path }}/{{ item.name }}/kubeconfig"
+    mode: 0640
+
 - name: Write cluster details into state file
   ansible.builtin.blockinfile:
     path: "{{ working_path }}/{{ clusters_details_file }}"


### PR DESCRIPTION
When deploying ocp cluster by using "ocp" role, in order to keep up with the consistency with other roles and ease clusters import flow with "acm_import_cluster" role, copy the kubeconfig file of each deployed cluster to the root of its directory.

This file will be fetched by the "acm_import_cluster" to perform the import of the cluster into the Hub.