### PR TITLE
[Managed Openshift] - Add state file removal

### DIFF
--- a/roles/managed_openshift/tasks/clusters_dirs.yml
+++ b/roles/managed_openshift/tasks/clusters_dirs.yml
@@ -17,3 +17,26 @@
     path: "{{ working_path }}/{{ item.name }}"
     state: "{{ state_step }}"
   loop: "{{ clusters_list }}"
+
+- block:
+    - name: Remove clusters details from the state file
+      ansible.builtin.blockinfile:
+        path: "{{ working_path }}/{{ clusters_details_file }}"
+        block: ""
+        marker: "#{mark} {{ item.name }} details"
+        state: absent
+      loop: "{{ clusters_list }}"
+
+    - name: Check the "{{ clusters_details_file }}" file
+      ansible.builtin.stat:
+        path: "{{ working_path }}/{{ clusters_details_file }}"
+      register: cl_file_state
+
+    - name: Delete the "{{ clusters_details_file }}" file if empty
+      ansible.builtin.file:
+        path: "{{ working_path }}/{{ clusters_details_file }}"
+        state: absent
+      when:
+        - cl_file_state.stat.exists
+        - cl_file_state.stat.size == 0
+  when: state == "absent"


### PR DESCRIPTION
When managed openshift cluster being deployed, a state file with clusters connection details being created.

While clusters deleted, the entries removed from the state file. Finally, the state file should be deleted if it's empty.