### PR TITLE
Combine cluster_details.yml file for all clusters

### DIFF
--- a/roles/acm_import_cluster/tasks/locate_kubeconfig_file.yml
+++ b/roles/acm_import_cluster/tasks/locate_kubeconfig_file.yml
@@ -6,9 +6,7 @@
 - name: Validate kubeconfig file existence
   ansible.builtin.stat:
     path: "{{ working_path }}/{{ dir }}/{{ item.name }}/kubeconfig"
-  loop:
-    - "{{ ocp_assets_dir }}"
-    - "{{ managed_openshift_dir }}"
+  loop: "{{ clusters_dir }}"
   loop_control:
     loop_var: dir
   register: dir_stat

--- a/roles/acm_import_cluster/vars/main.yml
+++ b/roles/acm_import_cluster/vars/main.yml
@@ -1,3 +1,4 @@
 ---
-ocp_assets_dir: logs/ocp_assets
-managed_openshift_dir: logs/managed_openshift
+clusters_dir:
+  - logs/ocp
+  - logs/managed_openshift

--- a/roles/cluster_login/tasks/main.yml
+++ b/roles/cluster_login/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Set ocp assets path
   ansible.builtin.set_fact:
-    working_path: "{{ lookup('env', 'PWD') }}/{{ ocp_assets_dir }}"
+    working_path: "{{ lookup('env', 'PWD') }}/{{ main_logs_dir }}"
 
 - name: Check for cluster details file
   ansible.builtin.stat:

--- a/roles/managed_openshift/tasks/aro/fetch_connection_details.yml
+++ b/roles/managed_openshift/tasks/aro/fetch_connection_details.yml
@@ -41,7 +41,7 @@
 
 - name: ARO - Write cluster details into state file
   ansible.builtin.blockinfile:
-    path: "{{ working_path }}/{{ clusters_details_file }}"
+    path: "{{ cl_details_file_path }}"
     block: |
       {{ item.name }}:
         console: {{ aro_cluster_urls.clusters.properties.consoleProfile.url }}
@@ -57,7 +57,7 @@
     msg: |
       Deployment of {{ item.name }} cluster succeeded.
 
-      Cluster connection details could be found here: {{ working_path }}/{{ clusters_details_file }}
+      Cluster connection details could be found here: {{ cl_details_file_path }}
       Cluster manifests files could be found here: {{ working_path }}/{{ item.name }}/
   ansible.builtin.set_fact:
     cl_state: "{{ cl_state | default([]) + msg.split('\n') }}"

--- a/roles/managed_openshift/tasks/clusters_dirs.yml
+++ b/roles/managed_openshift/tasks/clusters_dirs.yml
@@ -21,7 +21,7 @@
 - block:
     - name: Remove clusters details from the state file
       ansible.builtin.blockinfile:
-        path: "{{ working_path }}/{{ clusters_details_file }}"
+        path: "{{ cl_details_file_path }}"
         block: ""
         marker: "#{mark} {{ item.name }} details"
         state: absent
@@ -29,12 +29,12 @@
 
     - name: Check the "{{ clusters_details_file }}" file
       ansible.builtin.stat:
-        path: "{{ working_path }}/{{ clusters_details_file }}"
+        path: "{{ cl_details_file_path }}"
       register: cl_file_state
 
     - name: Delete the "{{ clusters_details_file }}" file if empty
       ansible.builtin.file:
-        path: "{{ working_path }}/{{ clusters_details_file }}"
+        path: "{{ cl_details_file_path }}"
         state: absent
       when:
         - cl_file_state.stat.exists

--- a/roles/managed_openshift/tasks/main.yml
+++ b/roles/managed_openshift/tasks/main.yml
@@ -1,7 +1,8 @@
 ---
 - name: Set managed openshift dir path
   ansible.builtin.set_fact:
-    working_path: "{{ lookup('env', 'PWD') }}/{{ managed_openshift_dir }}"
+    working_path: "{{ lookup('env', 'PWD') }}/{{ main_logs_dir }}/{{ clusters_dir }}"
+    cl_details_file_path: "{{ lookup('env', 'PWD') }}/{{ main_logs_dir }}/{{ clusters_details_file }}"
 
 - name: Process prerequisites
   ansible.builtin.include_tasks:

--- a/roles/managed_openshift/tasks/rosa/fetch_connection_details.yml
+++ b/roles/managed_openshift/tasks/rosa/fetch_connection_details.yml
@@ -54,7 +54,7 @@
 
 - name: ROSA - Write cluster details into state file
   ansible.builtin.blockinfile:
-    path: "{{ working_path }}/{{ clusters_details_file }}"
+    path: "{{ cl_details_file_path }}"
     block: |
       {{ item.name }}:
         console: {{ (rosa_cluster_url.stdout | from_json)['console']['url'] }}
@@ -90,7 +90,7 @@
     msg: |
       Deployment of {{ item.name }} cluster succeeded.
 
-      Cluster connection details could be found here: {{ working_path }}/{{ clusters_details_file }}
+      Cluster connection details could be found here: {{ cl_details_file_path }}
       Cluster manifests files could be found here: {{ working_path }}/{{ item.name }}/
   ansible.builtin.set_fact:
     cl_state: "{{ cl_state | default([]) + msg.split('\n') }}"

--- a/roles/managed_openshift/vars/main.yml
+++ b/roles/managed_openshift/vars/main.yml
@@ -1,5 +1,6 @@
 ---
-managed_openshift_dir: logs/managed_openshift
+main_logs_dir: logs
+clusters_dir: managed_openshift
 clusters_details_file: clusters_details.yml
 
 rosa_binary: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/rosa/latest/rosa-linux.tar.gz

--- a/roles/ocp/defaults/main.yml
+++ b/roles/ocp/defaults/main.yml
@@ -34,5 +34,3 @@ openshift_version:
 openshift_channel: stable
 openshift_install_binary: openshift-install-linux.tar.gz
 openshift_install_url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp
-ocp_assets_dir: logs/ocp_assets
-clusters_details_file: clusters_details.yml

--- a/roles/ocp/tasks/fetch_details.yml
+++ b/roles/ocp/tasks/fetch_details.yml
@@ -40,7 +40,7 @@
 
 - name: Write cluster details into state file
   ansible.builtin.blockinfile:
-    path: "{{ working_path }}/{{ clusters_details_file }}"
+    path: "{{ cl_details_file_path }}"
     block: |
       {{ item.name }}:
         console: {{ cluster_console }}
@@ -55,7 +55,7 @@
     msg: |
       Deployment of {{ item.name }} cluster succeeded.
 
-      Cluster connection details could be found here: {{ working_path }}/{{ clusters_details_file }}
+      Cluster connection details could be found here: {{ cl_details_file_path }}
       Cluster manifests files could be found here: {{ working_path }}/{{ item.name }}/
   ansible.builtin.set_fact:
     cl_state: "{{ cl_state | default([]) + msg.split('\n') }}"

--- a/roles/ocp/tasks/main.yml
+++ b/roles/ocp/tasks/main.yml
@@ -9,7 +9,8 @@
 
 - name: Set ocp assets path
   ansible.builtin.set_fact:
-    working_path: "{{ lookup('env', 'PWD') }}/{{ ocp_assets_dir }}"
+    working_path: "{{ lookup('env', 'PWD') }}/{{ main_logs_dir }}/{{ clusters_dir }}"
+    cl_details_file_path: "{{ lookup('env', 'PWD') }}/{{ main_logs_dir }}/{{ clusters_details_file }}"
 
 - name: Prepare clusters list
   ansible.builtin.include_tasks:
@@ -43,7 +44,7 @@
 
     - name: Remove clusters details from the state file
       ansible.builtin.blockinfile:
-        path: "{{ working_path }}/{{ clusters_details_file }}"
+        path: "{{ cl_details_file_path }}"
         block: ""
         marker: "#{mark} {{ item.name }} details"
         state: absent
@@ -51,12 +52,12 @@
 
     - name: Check the "{{ clusters_details_file }}" file
       ansible.builtin.stat:
-        path: "{{ working_path }}/{{ clusters_details_file }}"
+        path: "{{ cl_details_file_path }}"
       register: cl_file_state
 
     - name: Delete the "{{ clusters_details_file }}" file if empty
       ansible.builtin.file:
-        path: "{{ working_path }}/{{ clusters_details_file }}"
+        path: "{{ cl_details_file_path }}"
         state: absent
       when:
         - cl_file_state.stat.exists

--- a/roles/ocp/vars/main.yml
+++ b/roles/ocp/vars/main.yml
@@ -1,5 +1,4 @@
 ---
-cluster_login_name:
-
 main_logs_dir: logs
+clusters_dir: ocp
 clusters_details_file: clusters_details.yml


### PR DESCRIPTION
Diring deployment of clusters by using an "ocp" or "managed_openshift" roles, a "cluster_details.yml" file was created.
Separate file for each role.

In order to ease the management and provide the ability to use any other deployed cluster as hub, combine the both files into one single file. The file will be generated under "logs" directory and will contain any cluster being deployed by "ocp" and/or "managed_openshift" role.