### PR TITLE
[ACM] - Add source deployment method to ACM role

### DIFF
--- a/docs/acm.md
+++ b/docs/acm.md
@@ -32,6 +32,13 @@ The namespace that should be used for ACM MCH deployment.
 acm_namespace: open-cluster-management
 ```
 
+#### Deploy testing environment
+If it's "false", ACM will be deployed from official RH registry
+If it's "true", ACM will be deployed from downstream testing registry
+```
+deploy_test_env: false
+```
+
 #### Registry secrets
 During deployment of downstream MultiClusterHub, an access to internal registry is required.  
 For that we need to provide registry secrets.  

--- a/docs/config-sample.yml
+++ b/docs/config-sample.yml
@@ -119,7 +119,12 @@ acm_version: "2.8"  # When specifying an acm version, the last available will be
 # Sets the cluster that should be used for acm hub install.
 cluster_login_name:
 
+# If it's "false", ACM will be deployed from official RH registry
+# If it's "true", ACM will be deployed from downstream testing registry
+testing_deployment: false
+
 # Define any registry secrets that are required
+# For testing deployment only
 registry_secrets:
   - name: "quay.io:443"
     user: "<username>"

--- a/roles/acm/defaults/main.yml
+++ b/roles/acm/defaults/main.yml
@@ -9,10 +9,16 @@ cluster_pass:
 
 # Specify the version in the format of "2.8", "2.7"
 acm_version: "2.8"
+# Specific snapshot param defined only for testing deployment
 snapshot:
 
 acm_namespace: open-cluster-management
 
+# If it's "false", ACM will be deployed from official RH registry
+# If it's "true", ACM will be deployed from downstream testing registry
+deploy_test_env: false
+
+# For testing deployment only
 registry_secrets:
   - name: "quay.io:443"
     user: <username>

--- a/roles/acm/tasks/deploy.yml
+++ b/roles/acm/tasks/deploy.yml
@@ -1,24 +1,13 @@
-# The following two tasks represent the following bash command:
-# curl -s -X GET https://quay.io/api/v1/repository/acm-d/acm-custom-registry/tag/ \
-# | jq -S '.tags[] | {name: .name} | select(.name | startswith("2.8"))' | jq -r '.name' | head -1
-- name: Fetch downstream snapshots if snapshot not provided manually
-  ansible.builtin.uri:
-    url: "{{ registry_query_url }}/?filter_tag_name=like:{{ acm_version }}"
-    method: "GET"
-    status_code: 200
-  register: snap
-  when: snapshot is none
-
-- name: Select latest downstream snapshot according to provided version
-  ansible.builtin.set_fact:
-    snapshot: "{{ snap.json.tags
-      | selectattr('name', 'match', acm_version)
-      | map(attribute='name') | first }}"
-  when: snapshot is none
-
-- name: Print selected snapshot for ACM deployment
+- name: Define ACM deployment type
+  vars:
+    msg: |
+      {%- if not deploy_test_env | bool -%}
+      Deploying ACM {{ acm_version }} from official Red Hat registry
+      {%- elif deploy_test_env | bool -%}
+      Deploying ACM {{ acm_version }} from downstream testing registries
+      {%- endif -%}
   ansible.builtin.debug:
-    msg: "ACM version '{{ acm_version }}' with '{{ snapshot }}' snapshot will be deployed"
+    msg: "{{ msg.split('\n') }}"
 
 - name: Create namespace "{{ acm_namespace }}"
   community.okd.k8s:
@@ -30,18 +19,6 @@
     name: "{{ acm_namespace }}"
     state: present
 
-- name: Update cluster pull-secret secret
-  ansible.builtin.import_tasks:
-    file: update_pull_secret.yml
-
-- name: Create ImageContentSourcePolicy
-  community.okd.k8s:
-    host: "{{ cluster_api }}"
-    api_key: "{{ cluster_api_token }}"
-    validate_certs: false
-    definition: "{{ lookup('template', 'image-content-source-policy.yaml.j2') | from_yaml }}"
-    state: present
-
 - name: Create OperatorGroup
   community.okd.k8s:
     host: "{{ cluster_api }}"
@@ -50,29 +27,10 @@
     definition: "{{ lookup('template', 'operator-group.yaml.j2') | from_yaml }}"
     state: present
 
-- name: Create ACM CatalogSource
-  community.okd.k8s:
-    host: "{{ cluster_api }}"
-    api_key: "{{ cluster_api_token }}"
-    validate_certs: false
-    definition: "{{ lookup('template', 'catalog-source.yaml.j2') | from_yaml }}"
-    state: present
-  loop: "{{ catalog_sources }}"
-
-- name: Wait for ACM CatalogSource to get READY state
-  kubernetes.core.k8s_info:
-    host: "{{ cluster_api }}"
-    api_key: "{{ cluster_api_token }}"
-    validate_certs: false
-    api_version: operators.coreos.com/v1alpha1
-    kind: CatalogSource
-    name: "{{ item.catalog_name }}"
-    namespace: "{{ item.catalog_ns }}"
-  loop: "{{ catalog_sources }}"
-  register: acm_catalog
-  until: acm_catalog.resources[0].status.connectionState.lastObservedState == "READY"
-  retries: 15
-  delay: 10
+- name: Apply testing environment configuration
+  ansible.builtin.include_tasks:
+    file: test_env_config.yml
+  when: deploy_test_env | bool
 
 - name: Create ACM Subscription
   community.okd.k8s:

--- a/roles/acm/tasks/destroy.yml
+++ b/roles/acm/tasks/destroy.yml
@@ -19,16 +19,29 @@
     wait: true
     wait_timeout: 1200
 
-- name: Delete ACM CatalogSource
-  community.okd.k8s:
-    host: "{{ cluster_api }}"
-    api_key: "{{ cluster_api_token }}"
-    validate_certs: false
-    definition: "{{ lookup('template', 'catalog-source.yaml.j2') | from_yaml }}"
-    state: absent
-    wait: true
-    wait_timeout: 1200
-  loop: "{{ catalog_sources }}"
+- name: Delete testing configs
+  when: deploy_test_env | bool
+  block:
+    - name: Delete ACM CatalogSource
+      community.okd.k8s:
+        host: "{{ cluster_api }}"
+        api_key: "{{ cluster_api_token }}"
+        validate_certs: false
+        definition: "{{ lookup('template', 'catalog-source.yaml.j2') | from_yaml }}"
+        state: absent
+        wait: true
+        wait_timeout: 1200
+      loop: "{{ catalog_sources }}"
+
+    - name: Delete ImageContentSourcePolicy
+      community.okd.k8s:
+        host: "{{ cluster_api }}"
+        api_key: "{{ cluster_api_token }}"
+        validate_certs: false
+        definition: "{{ lookup('template', 'image-content-source-policy.yaml.j2') | from_yaml }}"
+        state: absent
+        wait: true
+        wait_timeout: 1200
 
 - name: Delete OperatorGroup
   community.okd.k8s:
@@ -36,16 +49,6 @@
     api_key: "{{ cluster_api_token }}"
     validate_certs: false
     definition: "{{ lookup('template', 'operator-group.yaml.j2') | from_yaml }}"
-    state: absent
-    wait: true
-    wait_timeout: 1200
-
-- name: Delete ImageContentSourcePolicy
-  community.okd.k8s:
-    host: "{{ cluster_api }}"
-    api_key: "{{ cluster_api_token }}"
-    validate_certs: false
-    definition: "{{ lookup('template', 'image-content-source-policy.yaml.j2') | from_yaml }}"
     state: absent
     wait: true
     wait_timeout: 1200

--- a/roles/acm/tasks/test_env_config.yml
+++ b/roles/acm/tasks/test_env_config.yml
@@ -1,0 +1,58 @@
+---
+# The following two tasks represent the following bash command:
+# curl -s -X GET https://quay.io/api/v1/repository/acm-d/acm-custom-registry/tag/ \
+# | jq -S '.tags[] | {name: .name} | select(.name | startswith("2.8"))' | jq -r '.name' | head -1
+- name: Fetch testing snapshots if snapshot not provided manually
+  ansible.builtin.uri:
+    url: "{{ registry_query_url }}/?filter_tag_name=like:{{ acm_version }}"
+    method: "GET"
+    status_code: 200
+  register: snap
+  when: snapshot is none
+
+- name: Select latest testing snapshot according to provided version
+  ansible.builtin.set_fact:
+    snapshot: "{{ snap.json.tags
+      | selectattr('name', 'match', acm_version)
+      | map(attribute='name') | first }}"
+  when: snapshot is none
+
+- name: Print selected snapshot for ACM deployment
+  ansible.builtin.debug:
+    msg: "ACM version '{{ acm_version }}' with '{{ snapshot }}' snapshot will be deployed"
+
+- name: Update cluster pull-secret secret
+  ansible.builtin.include_tasks:
+    file: update_pull_secret.yml
+
+- name: Create ImageContentSourcePolicy
+  community.okd.k8s:
+    host: "{{ cluster_api }}"
+    api_key: "{{ cluster_api_token }}"
+    validate_certs: false
+    definition: "{{ lookup('template', 'image-content-source-policy.yaml.j2') | from_yaml }}"
+    state: present
+
+- name: Create ACM CatalogSource
+  community.okd.k8s:
+    host: "{{ cluster_api }}"
+    api_key: "{{ cluster_api_token }}"
+    validate_certs: false
+    definition: "{{ lookup('template', 'catalog-source.yaml.j2') | from_yaml }}"
+    state: present
+  loop: "{{ catalog_sources }}"
+
+- name: Wait for ACM CatalogSource to get READY state
+  kubernetes.core.k8s_info:
+    host: "{{ cluster_api }}"
+    api_key: "{{ cluster_api_token }}"
+    validate_certs: false
+    api_version: operators.coreos.com/v1alpha1
+    kind: CatalogSource
+    name: "{{ item.catalog_name }}"
+    namespace: "{{ item.catalog_ns }}"
+  loop: "{{ catalog_sources }}"
+  register: acm_catalog
+  until: acm_catalog.resources[0].status.connectionState.lastObservedState == "READY"
+  retries: 15
+  delay: 10

--- a/roles/acm/templates/multiclusterhub.yaml.j2
+++ b/roles/acm/templates/multiclusterhub.yaml.j2
@@ -1,6 +1,7 @@
 apiVersion: operator.open-cluster-management.io/v1
 kind: MultiClusterHub
 metadata:
+{% if deploy_test_env | bool %}
   annotations:
 {% for catalog in catalog_sources %}
 {% if catalog.type == "mce" %}
@@ -8,7 +9,12 @@ metadata:
 {% endif %}
 {% endfor %}
     mch-imageRepository: "{{ acm_registry_mirror }}"
+{% endif %}
   name: multiclusterhub
   namespace: "{{ acm_namespace }}"
+{% if deploy_test_env | bool %}
 spec:
   imagePullSecret: multiclusterhub-operator-pull-secret
+{% else %}
+spec: {}
+{% endif %}

--- a/roles/acm/templates/subscription.yaml.j2
+++ b/roles/acm/templates/subscription.yaml.j2
@@ -7,9 +7,14 @@ spec:
   channel: "release-{{ acm_version }}"
   installPlanApproval: Automatic
   name: advanced-cluster-management
+{% if deploy_test_env | bool %}
 {% for catalog in catalog_sources %}
 {% if catalog.type == "acm" %}
   source: "{{ catalog.catalog_name }}"
   sourceNamespace: "{{ catalog.catalog_ns }}"
 {% endif %}
 {% endfor %}
+{% else %}
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+{% endif %}


### PR DESCRIPTION
Add a "downstream: true/false" parameter to control where ACM should be deployed from:
- Official RH registry
- Downstream (internal) testing registry