### PR TITLE
Separate identical "clusters_list" variables

### DIFF
--- a/roles/managed_openshift/tasks/clusters_dirs.yml
+++ b/roles/managed_openshift/tasks/clusters_dirs.yml
@@ -17,7 +17,7 @@
     path: "{{ working_path }}/{{ item.name }}"
     mode: '0755'
     state: "{{ state_step }}"
-  loop: "{{ clusters_list }}"
+  loop: "{{ managed_clusters_list }}"
 
 - name: Cleanup clusters entries
   when: state == "absent"
@@ -28,7 +28,7 @@
         block: ""
         marker: "#{mark} {{ item.name }} details"
         state: absent
-      loop: "{{ clusters_list }}"
+      loop: "{{ managed_clusters_list }}"
 
     - name: Check the file "{{ clusters_details_file }}"
       ansible.builtin.stat:

--- a/roles/managed_openshift/tasks/main.yml
+++ b/roles/managed_openshift/tasks/main.yml
@@ -9,11 +9,11 @@
     file: "{{ item.platform }}/prerequisites.yml"
   loop: "{{ managed_openshift_clusters }}"
 
-# Init clusters_list var so in case no clusters found to be removed
-# the flol just skip all tasks and not fail.
-- name: Init clusters_list var
+# Init managed_clusters_list var so in case no clusters found
+# to be removed the flow just skip all tasks and not fail.
+- name: Init managed_clusters_list var
   ansible.builtin.set_fact:
-    clusters_list: []
+    managed_clusters_list: []
 
 - name: Prepare clusters list
   ansible.builtin.include_tasks:
@@ -26,7 +26,7 @@
     - name: Delete cluster
       ansible.builtin.include_tasks:
         file: "{{ item.platform }}/delete.yml"
-      loop: "{{ clusters_list }}"
+      loop: "{{ managed_clusters_list }}"
 
     - name: Delete directories structure for destroyed clusters
       ansible.builtin.include_tasks:
@@ -38,22 +38,22 @@
     - name: Process cluster
       ansible.builtin.include_tasks:
         file: "{{ item.platform }}/process.yml"
-      loop: "{{ clusters_list }}"
+      loop: "{{ managed_clusters_list }}"
 
     - name: Wait for cluster provision to complete
       ansible.builtin.include_tasks:
         file: "{{ item.platform }}/wait_for_cluster.yml"
-      loop: "{{ clusters_list }}"
+      loop: "{{ managed_clusters_list }}"
 
     - name: Create ARO DNS records
       ansible.builtin.include_tasks:
         file: aro/dns_records.yml
-      loop: "{{ clusters_list }}"
+      loop: "{{ managed_clusters_list }}"
       when: item.platform == 'aro'
 
     - name: Combine newly created and existing clusters list
       ansible.builtin.set_fact:
-        clusters_list: "{{ clusters_list | default([]) + existing_clusters | default([]) }}"
+        managed_clusters_list: "{{ managed_clusters_list | default([]) + existing_managed_clusters | default([]) }}"
 
     - name: Create directory structure for clusters
       ansible.builtin.include_tasks:
@@ -62,7 +62,7 @@
     - name: Fetch connection details
       ansible.builtin.include_tasks:
         file: "{{ item.platform }}/fetch_connection_details.yml"
-      loop: "{{ clusters_list }}"
+      loop: "{{ managed_clusters_list }}"
 
     - name: Print clusters details
       ansible.builtin.debug:

--- a/roles/managed_openshift/tasks/prepare_clusters_list.yml
+++ b/roles/managed_openshift/tasks/prepare_clusters_list.yml
@@ -5,21 +5,21 @@
 
 - name: Create clusters list for creation
   ansible.builtin.set_fact:
-    clusters_list: "{{ clusters_list | default([]) + [item] }}"
+    managed_clusters_list: "{{ managed_clusters_list | default([]) + [item] }}"
   when:
     - state == "present"
     - not cl_exists
 
 - name: Create list of already existing clusters
   ansible.builtin.set_fact:
-    existing_clusters: "{{ existing_clusters | default([]) + [item] }}"
+    existing_managed_clusters: "{{ existing_managed_clusters | default([]) + [item] }}"
   when:
     - state == "present"
     - cl_exists
 
 - name: Create clusters list for deletion
   ansible.builtin.set_fact:
-    clusters_list: "{{ clusters_list | default([]) + [item] }}"
+    managed_clusters_list: "{{ managed_clusters_list | default([]) + [item] }}"
   when:
     - state == "absent"
     - cl_exists

--- a/roles/ocp/tasks/main.yml
+++ b/roles/ocp/tasks/main.yml
@@ -19,17 +19,17 @@
 - name: Prepare cloud credentials
   ansible.builtin.include_tasks:
     file: creds.yml
-  loop: "{{ clusters_list }}"
+  loop: "{{ ocp_clusters_list }}"
 
 - name: Prepare OCP cluster configuration
   ansible.builtin.include_tasks:
     file: prepare.yml
-  loop: "{{ clusters_list }}"
+  loop: "{{ ocp_clusters_list }}"
 
 - name: Select OpenShift version for deploy
   ansible.builtin.include_tasks:
     file: select_ocp_version.yml
-  loop: "{{ clusters_list }}"
+  loop: "{{ ocp_clusters_list }}"
 
 - name: Process OpenShift
   ansible.builtin.include_tasks:
@@ -42,7 +42,7 @@
       ansible.builtin.file:
         path: "{{ working_path }}/{{ item.name }}/"
         state: absent
-      loop: "{{ clusters_list }}"
+      loop: "{{ ocp_clusters_list }}"
 
     - name: Remove clusters details from the state file
       ansible.builtin.blockinfile:
@@ -50,7 +50,7 @@
         block: ""
         marker: "#{mark} {{ item.name }} details"
         state: absent
-      loop: "{{ clusters_list }}"
+      loop: "{{ ocp_clusters_list }}"
 
     - name: Check the file "{{ clusters_details_file }}"
       ansible.builtin.stat:
@@ -70,12 +70,12 @@
   block:
     - name: Combine newly created and existing clusters list
       ansible.builtin.set_fact:
-        clusters_list: "{{ clusters_list | default([]) + existing_clusters | default([]) }}"
+        ocp_clusters_list: "{{ ocp_clusters_list | default([]) + existing_ocp_clusters | default([]) }}"
 
     - name: Fetch OCP cluster details
       ansible.builtin.include_tasks:
         file: fetch_details.yml
-      loop: "{{ clusters_list }}"
+      loop: "{{ ocp_clusters_list }}"
 
     - name: Print clusters details
       ansible.builtin.debug:

--- a/roles/ocp/tasks/prepare_clusters_list.yml
+++ b/roles/ocp/tasks/prepare_clusters_list.yml
@@ -5,15 +5,15 @@
   loop: "{{ clusters }}"
   register: cluster_assets_dir
 
-# Init clusters_list var so in case no clusters found to be removed
+# Init ocp_clusters_list var so in case no clusters found to be removed
 # the flol just skip all tasks and not fail.
-- name: Init clusters_list var
+- name: Init ocp_clusters_list var
   ansible.builtin.set_fact:
-    clusters_list: []
+    ocp_clusters_list: []
 
-- name: Create clusters list for creation
+- name: Create ocp clusters list for creation
   ansible.builtin.set_fact:
-    clusters_list: "{{ clusters_list | default([]) + [item.item] }}"
+    ocp_clusters_list: "{{ ocp_clusters_list | default([]) + [item.item] }}"
   loop: "{{ cluster_assets_dir.results }}"
   when:
     - state == "present"
@@ -21,7 +21,7 @@
 
 - name: Create list of already existing clusters
   ansible.builtin.set_fact:
-    existing_clusters: "{{ existing_clusters | default([]) + [item.item] }}"
+    existing_ocp_clusters: "{{ existing_ocp_clusters | default([]) + [item.item] }}"
   loop: "{{ cluster_assets_dir.results }}"
   when:
     - state == "present"
@@ -29,7 +29,7 @@
 
 - name: Create clusters list for deletion
   ansible.builtin.set_fact:
-    clusters_list: "{{ clusters_list | default([]) + [item.item] }}"
+    ocp_clusters_list: "{{ ocp_clusters_list | default([]) + [item.item] }}"
   loop: "{{ cluster_assets_dir.results }}"
   when:
     - state == "absent"

--- a/roles/ocp/tasks/process.yml
+++ b/roles/ocp/tasks/process.yml
@@ -20,7 +20,7 @@
     cmd: "/tmp/openshift-install-{{ ocp_version_run }} {{ cluster_state }} cluster --dir {{ working_path }}/{{ item.name }}/"
   async: 3600
   poll: 0
-  loop: "{{ clusters_list }}"
+  loop: "{{ ocp_clusters_list }}"
   register: async_results
   changed_when: true
 


### PR DESCRIPTION
The "OCP" and "MANAGED_OPENSHIFT" roles have an identical variable - "clusters_list".
When executing the roles in one playbook execution, the "clusters_list" variables gets mixed and wrong items added to the list.

Separate the variables to become identical for each role.