### PR TITLE
[ACM_HIVE_CLUSTER] - Comment out default var

### DIFF
--- a/roles/acm_import_cluster/defaults/main.yml
+++ b/roles/acm_import_cluster/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 state: present
 
-acm_import_clusters:
-  # - name: cluster1
+# acm_import_clusters:
+#   - name: cluster1
 
 # Import cluster global addon flags
 acm_import_cluster_application_manager: true


### PR DESCRIPTION
In "acm_hive_cluster", the default variable "acm_import_clusters" is used to define the clusters that should be imported. But if this role is used in a general playbook that may need to skip the execution of the role, the definition of the variable with unexisting values may fail the execution of the entire playbook.

Comment out the default variable, so it will be defined only when explicitly used.