### PR TITLE
[CLUSTER_LOGIN] - Modify cluster login flow

### DIFF
--- a/roles/cluster_login/tasks/main.yml
+++ b/roles/cluster_login/tasks/main.yml
@@ -26,12 +26,16 @@
                   {{ cl_file | first }}
                   {%- endif -%}"
 
-    - name: Set cluster details
-      ansible.builtin.set_fact:
-        cl_api: "{{ cl_file[cl_name].api }}"
-        cl_user: "{{ cl_file[cl_name].user | default('kubeadmin') }}"
-        cl_pass: "{{ cl_file[cl_name].pass }}"
-      no_log: true
+- name: Set cluster details from the file if exists
+  ansible.builtin.set_fact:
+    cl_api: "{{ cl_file[cl_name].api }}"
+    cl_user: "{{ cl_file[cl_name].user | default('kubeadmin') }}"
+    cl_pass: "{{ cl_file[cl_name].pass }}"
+  no_log: true
+  when:
+    - cl_file_state.stat.exists
+    - cl_file_state.stat.size != 0
+    - cl_name in cl_file
 
 - name: Allocate cluster connection details
   ansible.builtin.set_fact:


### PR DESCRIPTION
The cluster_login role flow logins into the Openshift cluster in the following ways:
1) Looks for a "cluster_details.yml" file and takes from there the first
   defined cluster or specific cluster defined by the user.
2) If the file does not exist, but login environment variables are
   defined, use them.

The environment variables will take priority over cluster details file.

Currently, if cluster details file exists, but requested cluster entry is missing from it, even that environment variables defined, the flow will fail.

Modify the flow to make sure that if the cluster details file exists but missing the requested clsuter entry, but environment variable for connection are defined, move on and use the defined environment variables.