### PR TITLE
[MANAGED_OPENSHIFT] - Relocate ROKS login command

### DIFF
--- a/roles/managed_openshift/tasks/roks/check_cluster.yml
+++ b/roles/managed_openshift/tasks/roks/check_cluster.yml
@@ -3,12 +3,6 @@
   ansible.builtin.set_fact:
     cl_exists: false
 
-- name: ROKS - Login
-  ansible.builtin.command:
-    cmd: "{{ ibmcloud }} login --apikey {{ roks_creds.roks_token }} -r {{ item.region }}"
-  no_log: true
-  changed_when: false
-
 - name: ROKS - Check cluster existence
   ansible.builtin.command:
     cmd: "{{ ibmcloud }} ks cluster ls --provider vpc-gen2 --json"

--- a/roles/managed_openshift/tasks/roks/prerequisites.yml
+++ b/roles/managed_openshift/tasks/roks/prerequisites.yml
@@ -47,6 +47,12 @@
     cmd: "{{ ibmcloud }} plugin install container-service -f"
   changed_when: true
 
+- name: ROKS - Login
+  ansible.builtin.command:
+    cmd: "{{ ibmcloud }} login --apikey {{ roks_creds.roks_token }} -r {{ item.region }} -q"
+  no_log: true
+  changed_when: false
+
 - name: ROKS - Fetch IBM cloud account details
   ansible.builtin.command:
     cmd: "{{ ibmcloud }} account show --output json"


### PR DESCRIPTION
Relocate ROKS login command in "managed_openshift" role to be able to gather account id.