### PR TITLE
[MANAGED_OPENSHIFT] - Modify ROSA cluster version deploy

### DIFF
--- a/docs/config-sample.yml
+++ b/docs/config-sample.yml
@@ -324,7 +324,7 @@ managed_openshift_clusters:
       worker:
         type: m5.xlarge
         count: 3
-    openshift_version: "4.13.6"  # Optional. If not specified, will use the latest.
+    openshift_version: "4.15"
     skip_tls_verify: true  # Optional. Set the flag in the kubeconfig file.
 
   # ROKS cluster

--- a/docs/managed_openshift.md
+++ b/docs/managed_openshift.md
@@ -63,7 +63,7 @@ managed_openshift_clusters:
       worker:
         type: m5.xlarge
         count: 3
-    openshift_version: "4.13.6"  # Optional. If not specified, will use the latest.
+    openshift_version: "4.15"
     skip_tls_verify: true  # Optional. Set the flag in the kubeconfig file.
 
   # ROKS cluster

--- a/roles/managed_openshift/tasks/rosa/fetch_version.yml
+++ b/roles/managed_openshift/tasks/rosa/fetch_version.yml
@@ -1,0 +1,24 @@
+---
+- name: ROSA - Locate available Openshift version aligned with users input
+  ansible.builtin.command:
+    cmd: "{{ rosa }} list versions --output json"
+  register: rosa_ocp_ver
+  changed_when: false
+
+- name: ROSA - Identify the OCP version to deploy
+  block:
+    - name: ROSA - Identify the exact OCP version by to deploy by user request
+      ansible.builtin.set_fact:
+        ocp_version: "{{ rosa_ocp_ver.stdout
+          | from_json
+          | selectattr('raw_id', 'search', '^' + item.openshift_version)
+          | map(attribute='raw_id')
+          | first }}"
+
+    - name: ROSA - Print identified OCP version to deploy
+      ansible.builtin.debug:
+        msg: "Openshift version {{ ocp_version }} will be deployed"
+  rescue:
+    - name: ROSA - Fail the execution if requested OCP version is not found
+      ansible.builtin.fail:
+        msg: "ROSA - Requested version {{ item.openshift_version }} is not found. Try to change the version."

--- a/roles/managed_openshift/tasks/rosa/process.yml
+++ b/roles/managed_openshift/tasks/rosa/process.yml
@@ -38,6 +38,10 @@
   ansible.builtin.debug:
     msg: "{{ rosa_whoami.stdout_lines }}"
 
+- name: ROSA - Identify deployment version
+  ansible.builtin.include_tasks:
+    file: fetch_version.yml
+
 - name: ROSA - Create cluster
   ansible.builtin.command:
     cmd: |
@@ -51,9 +55,7 @@
       --compute-machine-type {{ item.machines.worker.type }}
       --replicas {{ item.machines.worker.count }}
       --channel-group {{ item.channel_group | default('stable') }}
-      {% if item.version is defined %}
-      --version {{ item.openshift_version }}
-      {% endif %}
+      --version {{ ocp_version }}
       {% if item.multi_az is defined and item.multi_az | bool %}
       --multi-az
       {% endif %}


### PR DESCRIPTION
Modify ROSA cluster version selection for deployment. With the change, the user should be able to define the requested version to be deployed instead of searching for specific version and defining it prior the deployment.

In the new flow, the requested version defined by the user, for example
- 4.15, will be automatically searched across available versions and the last availabe version will be selected for ROSA cluster deployment.