### PR TITLE
[MANAGED_OPENSHIFT] - Fix ROSA admin user creation

### DIFF
--- a/roles/managed_openshift/tasks/rosa/fetch_connection_details.yml
+++ b/roles/managed_openshift/tasks/rosa/fetch_connection_details.yml
@@ -15,12 +15,12 @@
 - name: Handle ROSA user creation
   block:
     - name: ROSA - Create admin user
-      ansible.builtin.command:
+      ansible.builtin.shell:
         cmd: |
-          {{ rosa }} --profile rhacm-automation
-          create admin
-          --cluster {{ item.name }}
-          --region {{ item.region }}
+          export AWS_REGION="{{ item.region }}"
+          {{ rosa }} --profile rhacm-automation \
+          create admin \
+          --cluster {{ item.name }} \
           -o json
       register: rosa_admin
       no_log: true
@@ -37,12 +37,12 @@
       changed_when: true
 
     - name: ROSA - Create admin user
-      ansible.builtin.command:
+      ansible.builtin.shell:
         cmd: |
-          {{ rosa }} --profile rhacm-automation
-          create admin
-          --cluster {{ item.name }}
-          --region {{ item.region }}
+          export AWS_REGION="{{ item.region }}"
+          {{ rosa }} --profile rhacm-automation \
+          create admin \
+          --cluster {{ item.name }} \
           -o json
       register: rosa_admin
       no_log: true


### PR DESCRIPTION
During the flow of admin user creation for ROSA cluster, admin credentials are fetched.
The flow always uses the latest ROSA binary to ensure the is no api break.

In the latest ROSA binary, during admin user creation, the following warning message appears:
"Region flag will be removed from this command in future versions"

This warning breaks the credentials fetch flow after the admin creation. Change the module and the command to avoid such an issue.