### PR TITLE
[MANAGED_OPENSHIFT] - Modify ARO cluster version deploy

### DIFF
--- a/docs/config-sample.yml
+++ b/docs/config-sample.yml
@@ -309,7 +309,7 @@ managed_openshift_clusters:
         type: Standard_D4s_v3
         disk_size: 128
         count: 3
-    openshift_version: "4.11.26"
+    openshift_version: "4.14"
 
   # ROSA cluster
   - name: cluster-rosa

--- a/docs/managed_openshift.md
+++ b/docs/managed_openshift.md
@@ -46,7 +46,7 @@ managed_openshift_clusters:
         type: Standard_D4s_v3
         disk_size: 128
         count: 3
-    openshift_version: "4.11.26"  # To check for available ARO versions, execute "az aro get-versions --location <location>" command.
+    openshift_version: "4.14"
 
   # ROSA cluster
   - name: cluster-rosa

--- a/plugins/modules/azure_rm_openshiftmanagedclusterversion_info.py
+++ b/plugins/modules/azure_rm_openshiftmanagedclusterversion_info.py
@@ -1,0 +1,135 @@
+#!/usr/bin/python
+#
+# Copyright (c) 2020 Haiyuan Zhang <haiyzhan@micosoft.com>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: azure_rm_openshiftmanagedclusterversion_info
+version_added: '2.5.0'
+short_description: Fetch available versions of Azure Red Hat OpenShift Managed Cluster
+description:
+    - fetch available version of Azure Red Hat OpenShift Managed Cluster instance.
+options:
+    location:
+        description:
+            - List install versions available for the defined region.
+        required: true
+        type: str
+extends_documentation_fragment:
+    - azure.azcollection.azure
+author:
+    - Maxim Babushkin (@maxbab)
+'''
+
+EXAMPLES = '''
+- name: Obtain openshift versions for ARO cluster
+  azure_rm_openshiftmanagedclusterversion_info:
+    location: centralus
+  register: ocp_versions
+
+- name: Print available openshift versions
+  debug:
+    msg: "{{ ocp_versions }}"
+'''
+
+RETURN = '''
+versions:
+    description:
+        - openshift versions values
+    returned: always
+    type: list
+'''
+
+import json
+from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBaseExt
+from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_rest import GenericRestClient
+
+
+class Actions:
+    NoAction, Create, Update, Delete = range(4)
+
+
+class AzureRMOpenShiftManagedClustersVersionInfo(AzureRMModuleBaseExt):
+    def __init__(self):
+        self.module_arg_spec = dict(
+            location=dict(
+                type='str', required=True
+            )
+        )
+
+        self.location = None
+
+        self.results = dict(changed=False)
+        self.mgmt_client = None
+        self.state = None
+        self.url = None
+        self.status_code = [200]
+
+        self.query_parameters = {}
+        self.query_parameters['api-version'] = '2023-11-22'
+        self.header_parameters = {}
+        self.header_parameters['Content-Type'] = 'application/json; charset=utf-8'
+
+        self.mgmt_client = None
+        super(AzureRMOpenShiftManagedClustersVersionInfo, self).__init__(self.module_arg_spec, supports_check_mode=True, supports_tags=False)
+
+    def exec_module(self, **kwargs):
+
+        for key in self.module_arg_spec:
+            setattr(self, key, kwargs[key])
+
+        self.mgmt_client = self.get_mgmt_svc_client(GenericRestClient,
+                                                    base_url=self._cloud_environment.endpoints.resource_manager)
+        self.results = self.get_versions()
+        return self.results
+
+    def get_versions(self):
+        response = None
+        resp_results = {}
+        results = {}
+        # prepare url
+        self.url = ('/subscriptions' +
+                    '/{{ subscription_id }}' +
+                    '/providers' +
+                    '/Microsoft.RedHatOpenShift' +
+                    '/locations' +
+                    '/{{ location }}' +
+                    '/openshiftversions')
+        self.url = self.url.replace('{{ subscription_id }}', self.subscription_id)
+        self.url = self.url.replace('{{ location }}', self.location)
+        self.log("Fetch versions of openshift cluster.")
+        try:
+            response = self.mgmt_client.query(self.url,
+                                              'GET',
+                                              self.query_parameters,
+                                              self.header_parameters,
+                                              None,
+                                              self.status_code,
+                                              600,
+                                              30)
+            resp_results = json.loads(response.text)
+        except Exception as e:
+            self.log('Could not get info for @(Model.ModuleOperationNameUpper).')
+        results['versions'] = self.format_versions(resp_results)
+        return results
+
+    def format_versions(self, version):
+        result = list()
+        if version.get('value'):
+            for ver in version['value']:
+                result.append(ver.get('properties').get('version'))
+        return result
+
+
+def main():
+    AzureRMOpenShiftManagedClustersVersionInfo()
+
+
+if __name__ == '__main__':
+    main()

--- a/roles/managed_openshift/tasks/aro/fetch_version.yml
+++ b/roles/managed_openshift/tasks/aro/fetch_version.yml
@@ -1,0 +1,20 @@
+---
+- name: ARO - Fetch available Openshift versions
+  azure_rm_openshiftmanagedclusterversion_info:
+    profile: rhacm-automation
+    location: "{{ item.region }}"
+  register: aro_cluster_vers
+
+- name: ARO - Identify the OCP version to deploy
+  block:
+    - name: ARO - Identify the exact OCP version by to deploy by user request
+      ansible.builtin.set_fact:
+        ocp_version: "{{ aro_cluster_vers.versions | select('search', item.openshift_version) | first }}"
+
+    - name: ARO - Print identified OCP version to deploy
+      ansible.builtin.debug:
+        msg: "Openshift version {{ ocp_version }} will be deployed"
+  rescue:
+    - name: ARO - Fail the execution if requested OCP version is not found
+      ansible.builtin.fail:
+        msg: "ARO - Requested version {{ item.openshift_version }} is not found. Try to change the version."

--- a/roles/managed_openshift/tasks/aro/process.yml
+++ b/roles/managed_openshift/tasks/aro/process.yml
@@ -50,6 +50,10 @@
   ansible.builtin.include_tasks:
     file: rbac.yml
 
+- name: ARO - Identify deployment version
+  ansible.builtin.include_tasks:
+    file: fetch_version.yml
+
 - name: ARO - Create cluster
   azure.azcollection.azure_rm_openshiftmanagedcluster:
     profile: rhacm-automation
@@ -59,7 +63,7 @@
     cluster_profile:
       domain: "{{ item.name }}.{{ item.base_domain }}"
       pull_secret: "{{ pull_secret | string }}"
-      version: "{{ item.openshift_version | default(omit) }}"
+      version: "{{ ocp_version }}"
     service_principal_profile:
       client_id: "{{ app_id }}"
       client_secret: "{{ subscription.client_secret }}"


### PR DESCRIPTION
Modify ARO cluster version selection for deployment. With the change, the user should be able to define the requested version to be deployed instead of searching for specific version and defining it prior the deployment.

In the new flow, the requested version defined by the user, for example
- 4.15, will be automatically searched across available versions and the last availabe version will be selected for ROSA cluster deployment.

A new azure collection module has been added to fetch available versions of openshift cluster to deploy.
A PR has been submitted to azure collection:
https://github.com/ansible-collections/azure/pull/1602