### PR TITLE
[ACM] - Modify ACM components management

### DIFF
--- a/roles/acm/defaults/main.yml
+++ b/roles/acm/defaults/main.yml
@@ -14,31 +14,32 @@ snapshot:
 
 acm_namespace: open-cluster-management
 
-acm_components:
-  - name: app-lifecycle
-    enabled: true
-  - name: cluster-lifecycle
-    enabled: true
-  - name: cluster-permission
-    enabled: true
-  - name: console
-    enabled: true
-  - name: grc
-    enabled: true
-  - name: insights
-    enabled: true
-  - name: multicluster-engine
-    enabled: true
-  - name: multicluster-observability
-    enabled: true
-  - name: search
-    enabled: false
-  - name: submariner-addon
-    enabled: true
-  - name: volsync
-    enabled: true
-  - name: cluster-backup
-    enabled: true
+# Define specific acm component and state to override the defaults
+# acm_components_overrides:
+#   - name: app-lifecycle
+#     enabled: true
+#   - name: cluster-lifecycle
+#     enabled: true
+#   - name: cluster-permission
+#     enabled: true
+#   - name: console
+#     enabled: true
+#   - name: grc
+#     enabled: true
+#   - name: insights
+#     enabled: true
+#   - name: multicluster-engine
+#     enabled: true
+#   - name: multicluster-observability
+#     enabled: true
+#   - name: search
+#     enabled: false
+#   - name: submariner-addon
+#     enabled: true
+#   - name: volsync
+#     enabled: false
+#   - name: cluster-backup
+#     enabled: true
 
 # If it's "false", ACM will be deployed from official RH registry
 # If it's "true", ACM will be deployed from downstream testing registry

--- a/roles/acm/templates/multiclusterhub.yaml.j2
+++ b/roles/acm/templates/multiclusterhub.yaml.j2
@@ -16,9 +16,11 @@ spec:
 {% if deploy_test_env | bool %}
   imagePullSecret: multiclusterhub-operator-pull-secret
 {% endif %}
+{% if acm_components_overrides[0] is defined %}
   overrides:
     components:
-{% for component in acm_components %}
+{% for component in acm_components_overrides %}
     - name: {{ component.name }}
       enabled: {{ component.enabled }}
 {% endfor %}
+{% endif %}


### PR DESCRIPTION
Modify ACM components enablement.
Instead of defining all the components for ACM for each deployment, modify it to define specific component to be enabled/disable if needed and the rest will take the default state of the ACM configuration.