### PR TITLE
[Cross roles] - Do not expose default vars

### DIFF
--- a/roles/acm_hive_cluster/defaults/main.yml
+++ b/roles/acm_hive_cluster/defaults/main.yml
@@ -11,18 +11,18 @@ ssh_key: |
     <private_ssh_key>
 
 # For other acm hive clusters platforms,
-# refer to README and config-sample.yml file.
-acm_hive_clusters:
-  - name: cluster1
-    credentials: cluster1-creds
-    platform: aws
-    region: us-east-2
-    network:
-      cluster: 10.128.0.0/14
-      machine: 10.0.0.0/16
-      service: 172.30.0.0/16
-      type: OVNKubernetes
-    hive_cluster_version: "4.12"
+# refer to role doc and config-sample.yml file.
+# acm_hive_clusters:
+#   - name: cluster1
+#     credentials: cluster1-creds
+#     platform: aws
+#     region: us-east-2
+#     network:
+#       cluster: 10.128.0.0/14
+#       machine: 10.0.0.0/16
+#       service: 172.30.0.0/16
+#       type: OVNKubernetes
+#     hive_cluster_version: "4.12"
 
 # For other credentials types,
 # refer to README and config-sample.yml file.

--- a/roles/managed_openshift/defaults/main.yml
+++ b/roles/managed_openshift/defaults/main.yml
@@ -4,44 +4,24 @@ state: present
 # OpenShift pull secret
 pull_secret:
 
-managed_openshift_clusters:
-  - name: cluster-aro
-    platform: aro
-    base_domain: example.com
-    credentials: aro-creds
-    region: centralus
-    network:
-      cluster: 10.128.0.0/14
-      service: 172.30.0.0/16
-    resource_group_name: <resource_group_name>
-    machines:
-      master:
-        type: Standard_D8s_v3
-      worker:
-        type: Standard_D4s_v3
-        disk_size: 128
-        count: 3
-    openshift_version: "4.11.26"
-  - name: cluster-rosa
-    platform: rosa
-    credentials: rosa-creds
-    region: us-east-2
-    network:
-      cluster: 10.128.0.0/14
-      machine: 10.0.0.0/16
-      service: 172.30.0.0/16
-    machines:
-      worker:
-        type: m5.xlarge
-        count: 3
-    openshift_version: "4.13.6"  # Optional. If not specified, will use the latest.
+# For other managed openshift clusters platforms,
+# refer to role doc and config-sample.yml file.
+# managed_openshift_clusters:
+#   - name: cluster-rosa
+#     platform: rosa
+#     credentials: rosa-creds
+#     region: us-east-2
+#     network:
+#       cluster: 10.128.0.0/14
+#       machine: 10.0.0.0/16
+#       service: 172.30.0.0/16
+#     machines:
+#       worker:
+#         type: m5.xlarge
+#         count: 3
+#     openshift_version: "4.15"
 
 managed_openshift_clusters_credentials:
-  - name: aro-creds
-    client_id: <client_id>
-    client_secret: <client_secret>
-    tenant_id: <tenant_id>
-    subscription_id: <subscription_id>
   - name: rosa-creds
     aws_access_key_id: <your_key>
     aws_secret_access_key: <your_secret_key>

--- a/roles/ocp/defaults/main.yml
+++ b/roles/ocp/defaults/main.yml
@@ -8,20 +8,22 @@ pull_secret:
 # Your SSH Public key
 ssh_pub_key:
 
-clusters:
-  - name: test-cluster
-    base_domain: example.com
-    credentials: aws-creds
-    network:
-      cluster: 10.128.0.0/14
-      machine: 10.0.0.0/16
-      service: 172.30.0.0/16
-      type: OVNKubernetes
-    cloud:
-      platform: aws
-      region: us-east-2
-      instance_type: m5.xlarge
-    openshift_version: "4.12"  # Optional variable to set OCP version per cluster
+# For other ocp clusters platforms,
+# refer to role doc and config-sample.yml file.
+# clusters:
+#   - name: test-cluster
+#     base_domain: example.com
+#     credentials: aws-creds
+#     network:
+#       cluster: 10.128.0.0/14
+#       machine: 10.0.0.0/16
+#       service: 172.30.0.0/16
+#       type: OVNKubernetes
+#     cloud:
+#       platform: aws
+#       region: us-east-2
+#       instance_type: m5.xlarge
+#     openshift_version: "4.12"  # Optional variable to set OCP version per cluster
 
 clusters_credentials:
   - name: aws-creds


### PR DESCRIPTION
Do not expose the default list of execution variables in roles to not create false execution parameters.