### PR TITLE
[ACM] - Modify ACM ICSP manifest

### DIFF
--- a/roles/acm/templates/image-content-source-policy.yaml.j2
+++ b/roles/acm/templates/image-content-source-policy.yaml.j2
@@ -10,6 +10,3 @@ spec:
   - mirrors:
     - "{{ acm_registry_mirror }}"
     source: registry.redhat.io/multicluster-engine
-  - mirrors:
-    - registry.redhat.io/openshift4/ose-oauth-proxy
-    source: registry.access.redhat.com/openshift4/ose-oauth-proxy


### PR DESCRIPTION
Modify the ICSP that is being created for ACM Hub deployment.
Remove the "registry.redhat.io/openshift4/ose-oauth-proxy" mirror configuration as it creates an issue in deploying the ACM Hub on ROSA cluster.