### PR TITLE
[MANAGED_OPENSHIFT] - Add retry to ROSA cluster creation task

### DIFF
--- a/roles/managed_openshift/tasks/rosa/process.yml
+++ b/roles/managed_openshift/tasks/rosa/process.yml
@@ -64,3 +64,7 @@
       {% endif %}
       --yes
   changed_when: true
+  register: rosa_cl_create
+  until: rosa_cl_create.rc == 0
+  retries: 2
+  delay: 10


### PR DESCRIPTION
When creating multiple ROSA clusters, sometimes, cluster creation command may fail.
Add a retry to avoid the failure.