### PR TITLE
[ACM] - Add conditional check to ACM catalog source

### DIFF
--- a/roles/acm/tasks/test_env_config.yml
+++ b/roles/acm/tasks/test_env_config.yml
@@ -53,6 +53,10 @@
     namespace: "{{ item.catalog_ns }}"
   loop: "{{ catalog_sources }}"
   register: acm_catalog
-  until: acm_catalog.resources[0].status.connectionState.lastObservedState == "READY"
+  until:
+    - "'status' in acm_catalog.resources[0]"
+    - "'connectionState' in acm_catalog.resources[0].status"
+    - "'lastObservedState' in acm_catalog.resources[0].status.connectionState"
+    - acm_catalog.resources[0].status.connectionState.lastObservedState == "READY"
   retries: 15
   delay: 10


### PR DESCRIPTION
Sometimes during deployment of ACM Hub, after CatalogSource creation, the status attribues could appear after small delay. In order to prevent the automation deployment failure, add graduate condition check for the status attributes.