### PR TITLE
Increase retries and timeouts for catalogsource

### DIFF
--- a/roles/acm/tasks/test_env_config.yml
+++ b/roles/acm/tasks/test_env_config.yml
@@ -58,5 +58,5 @@
     - "'connectionState' in acm_catalog.resources[0].status"
     - "'lastObservedState' in acm_catalog.resources[0].status.connectionState"
     - acm_catalog.resources[0].status.connectionState.lastObservedState == "READY"
-  retries: 15
-  delay: 10
+  retries: 30
+  delay: 20


### PR DESCRIPTION
Catalog source can take more time to get into READY state than currently configured which can lead to errors. Increase the retry and delay to reduce failures.